### PR TITLE
Allow specifying TLS Certificates via PEM strings

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -16,8 +16,11 @@ type Config struct {
 	HttpAuth      string `mapstructure:"http_auth"`
 	Token         string `mapstructure:"token"`
 	CAFile        string `mapstructure:"ca_file"`
+	CAPem         string `mapstructure:"ca_pem"`
 	CertFile      string `mapstructure:"cert_file"`
+	CertPEM       string `mapstructure:"cert_pem"`
 	KeyFile       string `mapstructure:"key_file"`
+	KeyPEM        string `mapstructure:"key_pem"`
 	CAPath        string `mapstructure:"ca_path"`
 	InsecureHttps bool   `mapstructure:"insecure_https"`
 	Namespace     string `mapstructure:"namespace"`
@@ -39,11 +42,20 @@ func (c *Config) Client() (*consulapi.Client, error) {
 	if c.CAFile != "" {
 		config.TLSConfig.CAFile = c.CAFile
 	}
+	if c.CAPem != "" {
+		config.TLSConfig.CAPem = []byte(c.CAPem)
+	}
 	if c.CertFile != "" {
 		config.TLSConfig.CertFile = c.CertFile
 	}
+	if c.CertPEM != "" {
+		config.TLSConfig.CertPEM = []byte(c.CertPEM)
+	}
 	if c.KeyFile != "" {
 		config.TLSConfig.KeyFile = c.KeyFile
+	}
+	if c.KeyPEM != "" {
+		config.TLSConfig.KeyPEM = []byte(c.KeyPEM)
 	}
 	if c.CAPath != "" {
 		config.TLSConfig.CAPath = c.CAPath

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -43,36 +43,42 @@ func Provider() terraform.ResourceProvider {
 			},
 
 			"ca_file": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CA_FILE", ""),
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_CA_FILE", ""),
+				ConflictsWith: []string{"ca_pem"},
 			},
 
 			"ca_pem": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"ca_file"},
 			},
 
 			"cert_file": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CERT_FILE", ""),
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_CERT_FILE", ""),
+				ConflictsWith: []string{"cert_pem"},
 			},
 
 			"cert_pem": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"cert_file"},
 			},
 
 			"key_file": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_KEY_FILE", ""),
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_KEY_FILE", ""),
+				ConflictsWith: []string{"key_pem"},
 			},
 
 			"key_pem": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"key_file"},
 			},
 
 			"ca_path": {

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -45,7 +45,7 @@ func Provider() terraform.ResourceProvider {
 			"ca_file": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_CA_FILE", ""),
+				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_CA_FILE", nil),
 				ConflictsWith: []string{"ca_pem"},
 			},
 
@@ -58,7 +58,7 @@ func Provider() terraform.ResourceProvider {
 			"cert_file": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_CERT_FILE", ""),
+				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_CERT_FILE", nil),
 				ConflictsWith: []string{"cert_pem"},
 			},
 
@@ -71,7 +71,7 @@ func Provider() terraform.ResourceProvider {
 			"key_file": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_KEY_FILE", ""),
+				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_KEY_FILE", nil),
 				ConflictsWith: []string{"key_pem"},
 			},
 

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -43,21 +43,42 @@ func Provider() terraform.ResourceProvider {
 			},
 
 			"ca_file": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CA_FILE", ""),
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_CA_FILE", ""),
+				ConflictsWith: []string{"ca_pem"},
+			},
+
+			"ca_pem": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"ca_file"},
 			},
 
 			"cert_file": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CERT_FILE", ""),
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_CERT_FILE", ""),
+				ConflictsWith: []string{"cert_pem"},
+			},
+
+			"cert_pem": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"cert_file"},
 			},
 
 			"key_file": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CONSUL_KEY_FILE", ""),
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_KEY_FILE", ""),
+				ConflictsWith: []string{"key_pem"},
+			},
+
+			"key_pem": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"key_file"},
 			},
 
 			"ca_path": {

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -43,42 +43,36 @@ func Provider() terraform.ResourceProvider {
 			},
 
 			"ca_file": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_CA_FILE", ""),
-				ConflictsWith: []string{"ca_pem"},
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CA_FILE", ""),
 			},
 
 			"ca_pem": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"ca_file"},
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			"cert_file": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_CERT_FILE", ""),
-				ConflictsWith: []string{"cert_pem"},
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CERT_FILE", ""),
 			},
 
 			"cert_pem": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"cert_file"},
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			"key_file": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("CONSUL_KEY_FILE", ""),
-				ConflictsWith: []string{"key_pem"},
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CONSUL_KEY_FILE", ""),
 			},
 
 			"key_pem": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"key_file"},
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			"ca_path": {

--- a/consul/resource_provider_test.go
+++ b/consul/resource_provider_test.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -56,6 +57,37 @@ func TestResourceProvider_ConfigureTLS(t *testing.T) {
 	}
 
 	err := rp.Configure(terraform.NewResourceConfigRaw(raw))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestResourceProvider_ConfigureTLSPem(t *testing.T) {
+	rp := Provider()
+
+	caPem, err := ioutil.ReadFile("test-fixtures/cacert.pem")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	certPem, err := ioutil.ReadFile("test-fixtures/usercert.pem")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	keyPem, err := ioutil.ReadFile("test-fixtures/userkey.pem")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	raw := map[string]interface{}{
+		"address":    "demo.consul.io:80",
+		"ca_pem":     string(caPem),
+		"cert_pem":   string(certPem),
+		"datacenter": "nyc3",
+		"key_pem":    string(keyPem),
+		"scheme":     "https",
+	}
+
+	err = rp.Configure(terraform.NewResourceConfigRaw(raw))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -57,8 +57,11 @@ The following arguments are supported:
 * `datacenter` - (Optional) The datacenter to use. Defaults to that of the agent.
 * `token` - (Optional) The ACL token to use by default when making requests to the agent. Can also be specified with `CONSUL_HTTP_TOKEN` or `CONSUL_TOKEN` as an environment variable.
 * `ca_file` - (Optional) A path to a PEM-encoded certificate authority used to verify the remote agent's certificate.
-* `cert_file` - (Optional) A path to a PEM-encoded certificate provided to the remote agent; requires use of `key_file`.
-* `key_file`- (Optional) A path to a PEM-encoded private key, required if `cert_file` is specified.
+* `ca_pem` - (Optional) PEM-encoded certificate authority used to verify the remote agent's certificate.
+* `cert_file` - (Optional) A path to a PEM-encoded certificate provided to the remote agent; requires use of `key_file` or `key_pem`.
+* `cert_pem` - (Optional) PEM-encoded certificate provided to the remote agent; requires use of `key_file` or `key_pem`.
+* `key_file`- (Optional) A path to a PEM-encoded private key, required if `cert_file` or `cert_pem` is specified.
+* `key_pem`- (Optional) PEM-encoded private key, required if `cert_file` or `cert_pem` is specified.
 * `ca_path` - (Optional) A path to a directory of PEM-encoded certificate authority files to use to check the authenticity of client and server connections. Can also be specified with the `CONSUL_CAPATH` environment variable.
 * `insecure_https`- (Optional) Boolean value to disable SSL certificate verification; setting this value to true is not recommended for production use. Only use this with scheme set to "https".
 


### PR DESCRIPTION
- Instead of paths only

```
Running tool: /usr/bin/go test -timeout 30s -run ^TestResourceProvider_ConfigureTLSPem$

2020/08/18 17:20:21 [INFO] Initializing Consul client
2020/08/18 17:20:21 [INFO] Consul Client configured with address: 'demo.consul.io:80', scheme: 'https', datacenter: 'nyc3', insecure_https: 'false'
PASS
ok  	github.com/terraform-providers/terraform-provider-consul/consul	0.029s

```