### PR TITLE
Fix typo in acl_token_secret_id datasource documentation

### DIFF
--- a/website/docs/d/acl_token_secret_id.html.markdown
+++ b/website/docs/d/acl_token_secret_id.html.markdown
@@ -41,7 +41,7 @@ data "consul_acl_token_secret_id" "read" {
 }
 
 output "consul_acl_token_secret_id" {
-  value = data.consul_acl_token.read.encrypted_secret_id
+  value = data.consul_acl_token_secret_id.read.encrypted_secret_id
 }
 ```
 


### PR DESCRIPTION
It should be `consul_acl_token_secret_id` instead of `consul_acl_token`

```
Error: Reference to undeclared resource

  on consul_token.tf line 22, in output "consul_acl_token_secret_id":
  22:   value = data.consul_acl_token.read.encrypted_secret_id

A data resource "consul_acl_token" "read" has not been declared in the root
module.```