### PR TITLE
Use docker mirror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ install:
 - bash scripts/gogetcookie.sh
 
 script:
-- docker run -v $PWD:/src bflad/tfproviderlint -S006 -S022 -S023 ./...
+- docker run -v $PWD:/src docker.mirror.hashicorp.services/bflad/tfproviderlint -S006 -S022 -S023 ./...
 - make test
 - docker run --rm
              -d
              --name consul-test
              -v $PWD/consul_test.hcl:/consul_test.hcl:ro
              -p 8500:8500
-             consul:latest consul agent -dev -config-file consul_test.hcl -client=0.0.0.0
+             docker.mirror.hashicorp.services/consul:latest consul agent -dev -config-file consul_test.hcl -client=0.0.0.0
 - make testacc TESTARGS="-count=1"
 - docker stop consul-test
 - docker run --rm
@@ -29,7 +29,7 @@ script:
              --name consul-test
              -v $PWD/consul_test.hcl:/consul_test.hcl:ro
              -p 8500:8500
-             hashicorp/consul-enterprise:latest consul agent -dev -config-file consul_test.hcl -client=0.0.0.0
+             docker.mirror.hashicorp.services/hashicorp/consul-enterprise:latest consul agent -dev -config-file consul_test.hcl -client=0.0.0.0
 - make testacc TESTARGS="-count=1"
 - docker stop consul-test
 - make vet

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=consul
 CONSUL_VERSION ?= "latest"
-CONSUL_IMAGE ?= "consul:$(CONSUL_VERSION)"
+CONSUL_IMAGE ?= "docker.mirror.hashicorp.services/consul:$(CONSUL_VERSION)"
 
 default: build
 


### PR DESCRIPTION
CHANGELOG: no impact

Dockerhub is going to rate limit unauthenticated pulls on November 1st. IPs from CI machines (with the exception of github acitons) will be near their limit all the time. We're moving projects to use a public un-rate-limited Mirror of these images instead. Let me know if you have any q's, otherwise feel free to merge when you can! 