### PR TITLE
Add namespaced token support to the consul_acl_token_secret_id data source

### DIFF
--- a/consul/data_source_consul_acl_token_secret_id.go
+++ b/consul/data_source_consul_acl_token_secret_id.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"fmt"
 
+	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/encryption"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -17,6 +18,11 @@ func dataSourceConsulACLTokenSecretID() *schema.Resource {
 			"accessor_id": {
 				Required: true,
 				Type:     schema.TypeString,
+			},
+
+			"namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			// Out parameters
@@ -43,7 +49,10 @@ func dataSourceConsulACLTokenSecretID() *schema.Resource {
 func dataSourceConsulACLTokenSecretIDRead(d *schema.ResourceData, meta interface{}) error {
 	client := getClient(meta)
 	accessorID := d.Get("accessor_id").(string)
-	aclToken, _, err := client.ACL().TokenRead(accessorID, nil)
+	qOpts := &consulapi.QueryOptions{
+		Namespace: getNamespace(d, meta),
+	}
+	aclToken, _, err := client.ACL().TokenRead(accessorID, qOpts)
 	if err != nil {
 		return err
 	}

--- a/consul/data_source_consul_acl_token_secret_id_test.go
+++ b/consul/data_source_consul_acl_token_secret_id_test.go
@@ -26,6 +26,37 @@ func TestAccDataACLTokenSecretID_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataACLTokenSecretID_namespaceCE(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { skipTestOnConsulEnterpriseEdition(t) },
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataACLTokenSecretIDConfigNamespaceCE,
+				ExpectError: namespaceEnterpriseFeature,
+			},
+		},
+	})
+}
+
+func TestAccDataACLTokenSecretID_namespaceEE(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { skipTestOnConsulCommunityEdition(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataACLTokenSecretIDConfigNamespaceEE,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.consul_acl_token_secret_id.read", "pgp_key", ""),
+					resource.TestCheckResourceAttr("data.consul_acl_token_secret_id.read", "encrypted_secret_id", ""),
+					resource.TestCheckResourceAttr("data.consul_acl_token_secret_id.read", "namespace", "test-data-token-secret"),
+					testAccCheckTokenExistsAndValidUUID("data.consul_acl_token_secret_id.read", "secret_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataACLTokenSecretID_PGP(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -92,5 +123,37 @@ resource "consul_acl_token" "test" {
 data "consul_acl_token_secret_id" "read" {
 	accessor_id = "${consul_acl_token.test.id}"
 	pgp_key     = "keybase:terraformacctest"
+}
+`
+
+const testAccDataACLTokenSecretIDConfigNamespaceCE = `
+data "consul_acl_token" "read" {
+  accessor_id = "foo"
+  namespace   = "test-data-token"
+}
+`
+
+const testAccDataACLTokenSecretIDConfigNamespaceEE = `
+resource "consul_namespace" "test" {
+  name = "test-data-token-secret"
+}
+
+resource "consul_acl_policy" "test" {
+  name        = "test"
+  rules       = "node \"\" { policy = \"read\" }"
+  datacenters = [ "dc1" ]
+  namespace   = consul_namespace.test.name
+}
+
+resource "consul_acl_token" "test" {
+  description = "test"
+  policies    = ["${consul_acl_policy.test.name}"]
+  local       = true
+  namespace   = consul_namespace.test.name
+}
+
+data "consul_acl_token_secret_id" "read" {
+  accessor_id = consul_acl_token.test.id
+  namespace   = consul_namespace.test.name
 }
 `

--- a/consul/data_source_consul_acl_token_secret_id_test.go
+++ b/consul/data_source_consul_acl_token_secret_id_test.go
@@ -147,7 +147,7 @@ resource "consul_acl_policy" "test" {
 
 resource "consul_acl_token" "test" {
   description = "test"
-  policies    = ["${consul_acl_policy.test.name}"]
+  policies    = [consul_acl_policy.test.name]
   local       = true
   namespace   = consul_namespace.test.name
 }

--- a/website/docs/d/acl_token_secret_id.html.markdown
+++ b/website/docs/d/acl_token_secret_id.html.markdown
@@ -51,6 +51,7 @@ output "consul_acl_token_secret_id" {
 The following arguments are supported:
 
 * `accessor_id` - (Required) The accessor ID of the ACL token.
+* `namespace` - (Optional, Enterprise Only) The namespace to lookup the token.
 * `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a keybase
   username in the form `keybase:some_person_that_exists`. **If you do not set this
   argument, the token secret ID will be written as plain text in the Terraform


### PR DESCRIPTION
This PR enabled the tf provider to retrieve the token secret for ACL tokens scoped to a namespace.