### PR TITLE
Gh issue 240

### DIFF
--- a/consul/resource_consul_acl_auth_method.go
+++ b/consul/resource_consul_acl_auth_method.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"time"
 
 	consulapi "github.com/hashicorp/consul/api"

--- a/consul/resource_consul_acl_auth_method.go
+++ b/consul/resource_consul_acl_auth_method.go
@@ -16,6 +16,15 @@ func resourceConsulACLAuthMethod() *schema.Resource {
 		Update: resourceConsulACLAuthMethodUpdate,
 		Delete: resourceConsulACLAuthMethodDelete,
 
+		CustomizeDiff: func(d *schema.ResourceDiff, meta interface{}) error {
+			new := d.Get("config").(map[string]interface{})
+			jsonNew := d.Get("config_json").(string)
+			if len(new) == 0 && jsonNew == "" {
+				return fmt.Errorf("One of 'config' or 'config_json' must be set")
+			}
+			return nil
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
@@ -76,13 +85,8 @@ func resourceConsulACLAuthMethod() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				ConflictsWith: []string{"config_json"},
-
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					config_json := d.Get("config_json").(string)
-					if (new == "") || (new == "0") {
-						return len(config_json) != 0
-					}
-					return false
+					return new == "" || new == "0"
 				},
 			},
 
@@ -91,13 +95,8 @@ func resourceConsulACLAuthMethod() *schema.Resource {
 				Optional:      true,
 				Description:   "The raw configuration for this ACL auth method.",
 				ConflictsWith: []string{"config"},
-
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					config := d.Get("config").(map[string]interface{})
-					if new == "" {
-						return len(config) != 0
-					}
-					return false
+					return new == "" || new == "0"
 				},
 			},
 
@@ -170,13 +169,21 @@ func resourceConsulACLAuthMethodRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Failed to set 'description': %v", err)
 	}
 
+	configJson, err := json.Marshal(authMethod.Config)
+	if err != nil {
+		return fmt.Errorf("Failed to marshal 'config_json': %v", err)
+	}
+	if err = d.Set("config_json", string(configJson)); err != nil {
+		return fmt.Errorf("Failed to set 'config_json': %v", err)
+	}
+
 	if err = d.Set("config", authMethod.Config); err != nil {
 		// When a complex configuration is used we can fail to set config as it
 		// will not support fields with maps or lists in them. In this case it
 		// means that the user used the 'config_json' field, and since we
 		// succeeded to set that and 'config' is deprecated, we can just use
 		// an empty placeholder value and ignore the error.
-		if c := d.Get("config_json").(string); c != "" && c != "0" {
+		if c := d.Get("config_json").(string); c != "" {
 			if err = d.Set("config", map[string]interface{}{}); err != nil {
 				return fmt.Errorf("Failed to set 'config': %v", err)
 			}

--- a/consul/resource_consul_acl_auth_method_test.go
+++ b/consul/resource_consul_acl_auth_method_test.go
@@ -139,13 +139,14 @@ resource "consul_acl_auth_method" "test" {
 	name        = "auth_method"
     type        = "kubernetes"
 
-	config = {
+	config_json  = jsonencode({
         Host = "https://localhost:8443"
 		CACert = <<-EOF
 ` + testCert2 + `
 		EOF
         ServiceAccountJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0IiwibmFtZSI6InRlc3QiLCJpYXQiOjE1MTYyMzkwMjJ9.uOnQsCs6ZAqj2F1VMA09tdgRZyFT1GQH2DwIC4TTn-A"
     }
+	)
 }`
 
 const testResourceACLAuthMethodConfigBasicConfigJSON = `


### PR DESCRIPTION
### Description

Conditional logic was preventing resource updates as described in issue 240

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?

- [x] Have you run the acceptance tests on this branch?


Output from acceptance testing:

```
make testacc TEST=./consul TESTARGS='-run=TestAccConsulACLAuthMethod'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./consul -v -run=TestAccConsulACLAuthMethod -timeout 120m
=== RUN   TestAccConsulACLAuthMethod_basic
--- PASS: TestAccConsulACLAuthMethod_basic (0.54s)
=== RUN   TestAccConsulACLAuthMethod_namespaceCE
--- PASS: TestAccConsulACLAuthMethod_namespaceCE (0.06s)
=== RUN   TestAccConsulACLAuthMethod_namespaceEE
    resource_consul_license_test.go:74: Test skipped on Consul Community Edition. Use a Consul Enterprise server to run this test.
--- SKIP: TestAccConsulACLAuthMethod_namespaceEE (0.02s)
PASS
ok      github.com/hashicorp/terraform-provider-consul/consul   0.899s        
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

Resolves #240

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
