### PR TITLE
Add new resource `consul_acl_token_role_attachment`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto

--- a/consul/resource_consul_acl_token_policy_attachment.go
+++ b/consul/resource_consul_acl_token_policy_attachment.go
@@ -78,7 +78,7 @@ func resourceConsulACLTokenPolicyAttachmentRead(d *schema.ResourceData, meta int
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL token policy attachment '%q'", id)
 
-	tokenID, policyName, err := parseTwoPartID(id)
+	tokenID, policyName, err := parseTwoPartID(id, "policy")
 	if err != nil {
 		return fmt.Errorf("Invalid ACL token policy attachment id '%q'", id)
 	}
@@ -124,7 +124,7 @@ func resourceConsulACLTokenPolicyAttachmentDelete(d *schema.ResourceData, meta i
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL token policy attachment '%q'", id)
 
-	tokenID, policyName, err := parseTwoPartID(id)
+	tokenID, policyName, err := parseTwoPartID(id, "policy")
 	if err != nil {
 		return fmt.Errorf("Invalid ACL token policy attachment id '%q'", id)
 	}
@@ -151,10 +151,10 @@ func resourceConsulACLTokenPolicyAttachmentDelete(d *schema.ResourceData, meta i
 }
 
 // return the pieces of id `a:b` as a, b
-func parseTwoPartID(id string) (string, string, error) {
+func parseTwoPartID(id, name string) (string, string, error) {
 	parts := strings.SplitN(id, ":", 2)
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Unexpected ID format (%q). Expected token_id:policy_name", id)
+		return "", "", fmt.Errorf("Unexpected ID format (%q). Expected token_id:%s_name", id, name)
 	}
 
 	return parts[0], parts[1], nil

--- a/consul/resource_consul_acl_token_policy_attachment_test.go
+++ b/consul/resource_consul_acl_token_policy_attachment_test.go
@@ -15,7 +15,7 @@ func testAccCheckConsulACLTokenPolicyAttachmentDestroy(s *terraform.State) error
 		if rs.Type != "consul_acl_token_policy_attachment" {
 			continue
 		}
-		tokenID, policyName, err := parseTwoPartID(rs.Primary.ID)
+		tokenID, policyName, err := parseTwoPartID(rs.Primary.ID, "policy")
 		if err != nil {
 			return fmt.Errorf("Invalid ACL token policy attachment id '%q'", rs.Primary.ID)
 		}

--- a/consul/resource_consul_acl_token_role_attachment.go
+++ b/consul/resource_consul_acl_token_role_attachment.go
@@ -1,0 +1,151 @@
+package consul
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceConsulACLTokenRoleAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceConsulACLTokenRoleAttachmentCreate,
+		Read:   resourceConsulACLTokenRoleAttachmentRead,
+		Delete: resourceConsulACLTokenRoleAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"token_id": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Description: "The token accessor id.",
+			},
+			"role": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Description: "The role name.",
+			},
+		},
+	}
+}
+
+func resourceConsulACLTokenRoleAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	client := getClient(meta)
+
+	log.Printf("[DEBUG] Creating ACL token role attachment")
+
+	tokenID := d.Get("token_id").(string)
+
+	aclToken, _, err := client.ACL().TokenRead(tokenID, nil)
+	if err != nil {
+		return fmt.Errorf("Token '%s' not found", tokenID)
+	}
+
+	roleName := d.Get("role").(string)
+	for _, role := range aclToken.Roles {
+		if role.Name == roleName {
+			return fmt.Errorf("Role '%s' already attached to token", roleName)
+		}
+	}
+
+	aclToken.Roles = append(aclToken.Roles, &consulapi.ACLTokenRoleLink{
+		Name: roleName,
+	})
+
+	_, _, err = client.ACL().TokenUpdate(aclToken, nil)
+	if err != nil {
+		return fmt.Errorf("Error updating ACL token '%q' to set new role attachment: '%s'", tokenID, err)
+	}
+
+	id := fmt.Sprintf("%s:%s", tokenID, roleName)
+
+	log.Printf("[DEBUG] Created ACL token role attachment '%q'", id)
+
+	d.SetId(id)
+
+	return resourceConsulACLTokenRoleAttachmentRead(d, meta)
+}
+
+func resourceConsulACLTokenRoleAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	client := getClient(meta)
+
+	id := d.Id()
+	log.Printf("[DEBUG] Reading ACL token role attachment '%q'", id)
+
+	tokenID, roleName, err := parseTwoPartID(id)
+	if err != nil {
+		return fmt.Errorf("Invalid ACL token role attachment id '%q'", id)
+	}
+
+	aclToken, _, err := client.ACL().TokenRead(tokenID, nil)
+	if err != nil {
+		if strings.Contains(err.Error(), "ACL not found") {
+			log.Printf("[WARN] ACL token not found, removing from state")
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Failed to read token '%s': %v", id, err)
+	}
+
+	log.Printf("[DEBUG] Read ACL token %q", tokenID)
+
+	roleFound := false
+	for _, role := range aclToken.Roles {
+		if role.Name == roleName {
+			roleFound = true
+			break
+		}
+	}
+	if !roleFound {
+		log.Printf("[WARN] ACL role not found in token, removing from state")
+		d.SetId("")
+		return nil
+	}
+
+	if err = d.Set("token_id", tokenID); err != nil {
+		return fmt.Errorf("Error while setting 'token_id': %s", err)
+	}
+	if err = d.Set("role", roleName); err != nil {
+		return fmt.Errorf("Error while setting 'role': %s", err)
+	}
+
+	return nil
+}
+
+func resourceConsulACLTokenRoleAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	client := getClient(meta)
+
+	id := d.Id()
+	log.Printf("[DEBUG] Reading ACL token role attachment '%q'", id)
+
+	tokenID, roleName, err := parseTwoPartID(id)
+	if err != nil {
+		return fmt.Errorf("Invalid ACL token role attachment id '%q'", id)
+	}
+
+	aclToken, _, err := client.ACL().TokenRead(tokenID, nil)
+	if err != nil {
+		return fmt.Errorf("Token '%s' not found", tokenID)
+	}
+
+	for i, role := range aclToken.Roles {
+		if role.Name == roleName {
+			aclToken.Roles = append(aclToken.Roles[:i], aclToken.Roles[i+1:]...)
+			break
+		}
+	}
+
+	_, _, err = client.ACL().TokenUpdate(aclToken, nil)
+	if err != nil {
+		return fmt.Errorf("Error updating ACL token '%q' to set new role attachment: '%s'", tokenID, err)
+	}
+	log.Printf("[DEBUG] Deleted ACL token attachment role %q", id)
+
+	return nil
+}

--- a/consul/resource_consul_acl_token_role_attachment.go
+++ b/consul/resource_consul_acl_token_role_attachment.go
@@ -78,7 +78,7 @@ func resourceConsulACLTokenRoleAttachmentRead(d *schema.ResourceData, meta inter
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL token role attachment '%q'", id)
 
-	tokenID, roleName, err := parseTwoPartID(id)
+	tokenID, roleName, err := parseTwoPartID(id, "role")
 	if err != nil {
 		return fmt.Errorf("Invalid ACL token role attachment id '%q'", id)
 	}
@@ -124,7 +124,7 @@ func resourceConsulACLTokenRoleAttachmentDelete(d *schema.ResourceData, meta int
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL token role attachment '%q'", id)
 
-	tokenID, roleName, err := parseTwoPartID(id)
+	tokenID, roleName, err := parseTwoPartID(id, "role")
 	if err != nil {
 		return fmt.Errorf("Invalid ACL token role attachment id '%q'", id)
 	}

--- a/consul/resource_consul_acl_token_role_attachment_test.go
+++ b/consul/resource_consul_acl_token_role_attachment_test.go
@@ -15,7 +15,7 @@ func testAccCheckConsulACLTokenRoleAttachmentDestroy(s *terraform.State) error {
 		if rs.Type != "consul_acl_token_role_attachment" {
 			continue
 		}
-		tokenID, roleName, err := parseTwoPartID(rs.Primary.ID)
+		tokenID, roleName, err := parseTwoPartID(rs.Primary.ID, "role")
 		if err != nil {
 			return fmt.Errorf("Invalid ACL token role attachment id '%q'", rs.Primary.ID)
 		}
@@ -130,7 +130,7 @@ func TestAccConsulACLTokenRoleAttachment_import(t *testing.T) {
 const testResourceACLTokenRoleAttachmentConfigBasic = `
 resource "consul_acl_role" "test" {
 	name = "test"
-	
+
 	service_identities {
         service_name = "foo"
     }
@@ -155,7 +155,7 @@ const testResourceACLTokenRoleAttachmentConfigUpdate = `
 // Using another resource to force the update of consul_acl_token
 resource "consul_acl_role" "test2" {
 	name = "test2"
-	
+
 	service_identities {
         service_name = "bar"
     }

--- a/consul/resource_consul_acl_token_role_attachment_test.go
+++ b/consul/resource_consul_acl_token_role_attachment_test.go
@@ -1,0 +1,176 @@
+package consul
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func testAccCheckConsulACLTokenRoleAttachmentDestroy(s *terraform.State) error {
+	client := getClient(testAccProvider.Meta())
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "consul_acl_token_role_attachment" {
+			continue
+		}
+		tokenID, roleName, err := parseTwoPartID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Invalid ACL token role attachment id '%q'", rs.Primary.ID)
+		}
+		aclToken, _, _ := client.ACL().TokenRead(tokenID, nil)
+		if aclToken != nil {
+			for _, role := range aclToken.Roles {
+				if role.Name == roleName {
+					return fmt.Errorf("ACL token role attachment %q still exists", rs.Primary.ID)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func testAccCheckTokenRoleName(s *terraform.State) error {
+	rs, ok := s.RootModule().Resources["consul_acl_token.test"]
+	if !ok {
+		return fmt.Errorf("Not Found: consul_acl_token.test")
+	}
+
+	tokenID := rs.Primary.Attributes["id"]
+	if tokenID == "" {
+		return fmt.Errorf("No token ID is set")
+	}
+
+	client := getClient(testAccProvider.Meta())
+	_, _, err := client.ACL().TokenRead(tokenID, nil)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve token %q", tokenID)
+	}
+
+	// Make sure the role has the same token_id
+	rs, ok = s.RootModule().Resources["consul_acl_token_role_attachment.test"]
+	if !ok {
+		return fmt.Errorf("Not Found: consul_acl_token_role_attachment.test")
+	}
+
+	roleTokenID := rs.Primary.Attributes["token_id"]
+	if roleTokenID == "" {
+		return fmt.Errorf("No role token_id is set")
+	}
+
+	if roleTokenID != tokenID {
+		return fmt.Errorf("%s != %s", roleTokenID, tokenID)
+	}
+
+	return nil
+}
+
+func TestAccConsulACLTokenRoleAttachment_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckConsulACLTokenRoleAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLTokenRoleAttachmentConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTokenRoleName,
+					resource.TestCheckResourceAttr("consul_acl_token_role_attachment.test", "role", "test"),
+				),
+			},
+			{
+				Config: testResourceACLTokenRoleAttachmentConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTokenRoleName,
+					resource.TestCheckResourceAttr("consul_acl_token_role_attachment.test", "role", "test2"),
+				),
+			},
+			{
+				Config: testResourceACLTokenRoleAttachmentConfigUpdate,
+			},
+		},
+	})
+}
+
+func TestAccConsulACLTokenRoleAttachment_import(t *testing.T) {
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("bad state: %s", s)
+		}
+		_, ok := s[0].Attributes["token_id"]
+		if !ok {
+			return fmt.Errorf("bad token_id: %s", s)
+		}
+		_, ok = s[0].Attributes["role"]
+		if !ok {
+			return fmt.Errorf("bad role: %s", s)
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLTokenRoleAttachmentConfigBasic,
+			},
+			{
+				ResourceName:     "consul_acl_token_role_attachment.test",
+				ImportState:      true,
+				ImportStateCheck: checkFn,
+			},
+		},
+	})
+}
+
+const testResourceACLTokenRoleAttachmentConfigBasic = `
+resource "consul_acl_role" "test" {
+	name = "test"
+	
+	service_identities {
+        service_name = "foo"
+    }
+}
+
+resource "consul_acl_token" "test" {
+	description = "test"
+	local = true
+
+	lifecycle {
+		ignore_changes = ["roles"]
+	}
+}
+
+resource "consul_acl_token_role_attachment" "test" {
+    token_id = "${consul_acl_token.test.id}"
+    role  = "${consul_acl_role.test.name}"
+}
+`
+
+const testResourceACLTokenRoleAttachmentConfigUpdate = `
+// Using another resource to force the update of consul_acl_token
+resource "consul_acl_role" "test2" {
+	name = "test2"
+	
+	service_identities {
+        service_name = "bar"
+    }
+}
+
+resource "consul_acl_token" "test" {
+	description = "test"
+	roles = []
+
+	lifecycle {
+		ignore_changes = ["roles"]
+	}
+}
+
+resource "consul_acl_token_role_attachment" "test" {
+    token_id = "${consul_acl_token.test.id}"
+    role = "${consul_acl_role.test2.name}"
+}`

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -143,6 +143,7 @@ func Provider() terraform.ResourceProvider {
 			"consul_acl_role":                    resourceConsulACLRole(),
 			"consul_acl_token":                   resourceConsulACLToken(),
 			"consul_acl_token_policy_attachment": resourceConsulACLTokenPolicyAttachment(),
+			"consul_acl_token_role_attachment":   resourceConsulACLTokenRoleAttachment(),
 			"consul_agent_service":               resourceConsulAgentService(),
 			"consul_catalog_entry":               resourceConsulCatalogEntry(),
 			"consul_certificate_authority":       resourceConsulCertificateAuthority(),

--- a/website/docs/r/acl_token_policy_attachment.html.markdown
+++ b/website/docs/r/acl_token_policy_attachment.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # consul_acl_token_policy_attachment
 
-The `consul_acl_token_attachment` resource links a Consul Token and an ACL
+The `consul_acl_token_policy_attachment` resource links a Consul Token and an ACL
 policy. The link is implemented through an update to the Consul ACL token.
 
 ~> **NOTE:** This resource is only useful to attach policies to an ACL token

--- a/website/docs/r/acl_token_role_attachment.html.markdown
+++ b/website/docs/r/acl_token_role_attachment.html.markdown
@@ -1,0 +1,101 @@
+---
+layout: "consul"
+page_title: "Consul: consul_acl_token_role_attachment"
+sidebar_current: "docs-consul-resource-acl-tr-attachment"
+description: |-
+  Allows Terraform to create a link between an ACL token and a role
+---
+
+# consul_acl_token_role_attachment
+
+The `consul_acl_token_role_attachment` resource links a Consul Token and an ACL
+role. The link is implemented through an update to the Consul ACL token.
+
+~> **NOTE:** This resource is only useful to attach roles to an ACL token
+that has been created outside the current Terraform configuration, like the
+anonymous or the master token. If the token you need to attach a policy to has
+been created in the current Terraform configuration and will only be used in it,
+you should use the `roles` attribute of [`consul_acl_token`](/docs/providers/consul/r/acl_token.html).
+
+## Example Usage
+
+### Attach a role to the anonymous token
+
+```hcl
+resource "consul_acl_role" "role" {
+  name = "foo"
+  description = "Foo"
+
+  service_identities {
+    service_name = "foo"
+  }
+}
+
+resource "consul_acl_token_role_attachment" "attachment" {
+  token_id = "00000000-0000-0000-0000-000000000002"
+  role_id  = consul_acl_role.role.id
+}
+```
+
+### Attach a policy to a token created in another Terraform configuration
+
+#### In `first_configuration/main.tf`
+
+```hcl
+resource "consul_acl_token" "test" {
+  accessor_id = "5914ee49-eb8d-4837-9767-9299ec155000"
+  description = "my test token"
+  local = true
+
+  lifecycle {
+    ignore_changes = ["roles"]
+  }
+}
+```
+
+#### In `second_configuration/main.tf`
+
+```hcl
+resource "consul_acl_role" "role" {
+  name = "foo"
+  description = "Foo"
+
+  service_identities {
+    service_name = "foo"
+  }
+}
+
+resource "consul_acl_token_role_attachment" "attachment" {
+  token_id = "00000000-0000-0000-0000-000000000002"
+  role_id  = consul_acl_role.role.id
+}
+```
+**NOTE**: `consul_acl_token` would attempt to enforce an empty set of roles,
+because its `roles` attribute is empty. For this reason it is necessary to add
+the lifecycle clause to prevent Terraform from attempting to empty the set of
+roles associated to the token.
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `token_id` - (Required) The id of the token.
+* `role_id` - (Required) The id of the role to attach to the token.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The attachment ID.
+* `token_id` - The id of the token.
+* `role_id` - The id of the role attached to the token.
+
+
+## Import
+
+`consul_acl_token_role_attachment` can be imported. This is especially useful to manage the
+policies attached to the anonymous and the master tokens with Terraform:
+
+```
+$ terraform import consul_acl_token_role_attachment.anonymous token_id:role_id
+```

--- a/website/docs/r/acl_token_role_attachment.html.markdown
+++ b/website/docs/r/acl_token_role_attachment.html.markdown
@@ -72,7 +72,7 @@ resource "consul_acl_token_role_attachment" "attachment" {
 ```
 **NOTE**: `consul_acl_token` would attempt to enforce an empty set of roles,
 because its `roles` attribute is empty. For this reason it is necessary to add
-the lifecycle clause to prevent Terraform from attempting to empty the set of
+the lifecycle clause to prevent Terraform from attempting to clear the set of
 roles associated to the token.
 
 ## Argument Reference


### PR DESCRIPTION
This PR adds a new resource `consul_acl_token_role_attachment` that operates in the same fashion as the existing `consul_acl_token_policy_attachment`. This allows for the attachment of service identity policies supported through the `consul_acl_role` resource to existing tokens. 

The biggest use-case for me personally is to attach _policy_ to terminating gateway tokens that have been provisioned externally to the code provisioning the service which wants to make use of the terminating gateway. This can already be achieved using the `consul_acl_policy` and `consul_acl_token_policy_attachment` resources. However, the `consul_acl_role` offers a nice shortcut to creating the service identity policy. This pattern is also recommended in 
https://learn.hashicorp.com/tutorials/consul/service-mesh-terminating-gateways?in=consul/developer-mesh:
```
We suggest you implement this configuration by updating the service identities for the role attached to the
terminating gateway token. Role updates can be done centrally, and you will not need to distribute a new
token.
```