### PR TITLE
Fix the way datacenter, token and namespace are inherited from the provider configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,13 @@ script:
              --name consul-test-dc2
              -v $PWD/consul_test_dc2.hcl:/consul_test_dc2.hcl:ro
              --net host
-             docker.mirror.hashicorp.services/consul-enterprise:latest consul agent -dev -config-file consul_test_dc2.hcl
+             docker.mirror.hashicorp.services/hashicorp/consul-enterprise:latest consul agent -dev -config-file consul_test_dc2.hcl
 - docker run --rm
              -d
              --name consul-test
              -v $PWD/consul_test.hcl:/consul_test.hcl:ro
              --net host
-             docker.mirror.hashicorp.services/consul-enterprise:latest consul agent -dev -config-file consul_test.hcl
+             docker.mirror.hashicorp.services/hashicorp/consul-enterprise:latest consul agent -dev -config-file consul_test.hcl
 - TEST_REMOTE_DATACENTER=1 make testacc TESTARGS="-count=1"
 - docker stop consul-test consul-test-dc2
 - make vet

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,34 @@ script:
              docker.mirror.hashicorp.services/hashicorp/consul-enterprise:latest consul agent -dev -config-file consul_test.hcl -client=0.0.0.0
 - make testacc TESTARGS="-count=1"
 - docker stop consul-test
+- docker run --rm
+             -d
+             --name consul-test-dc2
+             -v $PWD/consul_test_dc2.hcl:/consul_test_dc2.hcl:ro
+             --net host
+             docker.mirror.hashicorp.services/consul:latest consul agent -dev -config-file consul_test_dc2.hcl
+- docker run --rm
+             -d
+             --name consul-test
+             -v $PWD/consul_test.hcl:/consul_test.hcl:ro
+             --net host
+             docker.mirror.hashicorp.services/consul:latest consul agent -dev -config-file consul_test.hcl
+- TEST_REMOTE_DATACENTER=1 make testacc TESTARGS="-count=1"
+- docker stop consul-test consul-test-dc2
+- docker run --rm
+             -d
+             --name consul-test-dc2
+             -v $PWD/consul_test_dc2.hcl:/consul_test_dc2.hcl:ro
+             --net host
+             docker.mirror.hashicorp.services/consul-enterprise:latest consul agent -dev -config-file consul_test_dc2.hcl
+- docker run --rm
+             -d
+             --name consul-test
+             -v $PWD/consul_test.hcl:/consul_test.hcl:ro
+             --net host
+             docker.mirror.hashicorp.services/consul-enterprise:latest consul agent -dev -config-file consul_test.hcl
+- TEST_REMOTE_DATACENTER=1 make testacc TESTARGS="-count=1"
+- docker stop consul-test consul-test-dc2
 - make vet
 
 branches:

--- a/README.md
+++ b/README.md
@@ -114,3 +114,14 @@ locally and then run it in development mode:
 ```
 $ consul agent -dev
 ```
+
+It is also possible to run additional tests to test the provider with multiple
+datacenters:
+
+```sh
+$ consul agent -dev -config-file ./consul_test_dc2.hcl &
+$ consul agent -dev -config-file ./consul_test.hcl &
+$ export CONSUL_HTTP_ADDR=localhost:8500
+$ export CONSUL_HTTP_TOKEN=master-token
+$ TEST_REMOTE_DATACENTER=1 make testacc
+```

--- a/consul/data_source_consul_acl_auth_method.go
+++ b/consul/data_source_consul_acl_auth_method.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -86,16 +85,8 @@ func dataSourceConsulACLAuthMethod() *schema.Resource {
 }
 
 func dataSourceConsulACLAuthMethodRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 	name := d.Get("name").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return fmt.Errorf("Failed to get DC: %v", err)
-	}
-	qOpts := &consulapi.QueryOptions{
-		Datacenter: dc,
-		Namespace:  getNamespace(d, meta),
-	}
 
 	authMethod, _, err := client.ACL().AuthMethodRead(name, qOpts)
 	if err != nil {

--- a/consul/data_source_consul_acl_policy.go
+++ b/consul/data_source_consul_acl_policy.go
@@ -41,16 +41,8 @@ func dataSourceConsulACLPolicy() *schema.Resource {
 }
 
 func dataSourceConsulACLPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 	name := d.Get("name").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return fmt.Errorf("Failed to get DC: %v", err)
-	}
-	qOpts := &consulapi.QueryOptions{
-		Datacenter: dc,
-		Namespace:  getNamespace(d, meta),
-	}
 
 	var policyEntry *consulapi.ACLPolicyListEntry
 	policyEntries, _, err := client.ACL().PolicyList(qOpts)

--- a/consul/data_source_consul_acl_role.go
+++ b/consul/data_source_consul_acl_role.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"fmt"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -69,16 +68,8 @@ func dataSourceConsulACLRole() *schema.Resource {
 }
 
 func datasourceConsulACLRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 	name := d.Get("name").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return fmt.Errorf("Failed to get DC: %v", err)
-	}
-	qOpts := &consulapi.QueryOptions{
-		Datacenter: dc,
-		Namespace:  getNamespace(d, meta),
-	}
 
 	role, _, err := client.ACL().RoleReadByName(name, qOpts)
 	if err != nil {

--- a/consul/data_source_consul_acl_token.go
+++ b/consul/data_source_consul_acl_token.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"fmt"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -56,11 +55,9 @@ func dataSourceConsulACLToken() *schema.Resource {
 }
 
 func dataSourceConsulACLTokenRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 	accessorID := d.Get("accessor_id").(string)
-	qOpts := &consulapi.QueryOptions{
-		Namespace: getNamespace(d, meta),
-	}
+
 	aclToken, _, err := client.ACL().TokenRead(accessorID, qOpts)
 	if err != nil {
 		return err

--- a/consul/data_source_consul_acl_token_secret_id.go
+++ b/consul/data_source_consul_acl_token_secret_id.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"fmt"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/encryption"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -47,11 +46,9 @@ func dataSourceConsulACLTokenSecretID() *schema.Resource {
 }
 
 func dataSourceConsulACLTokenSecretIDRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 	accessorID := d.Get("accessor_id").(string)
-	qOpts := &consulapi.QueryOptions{
-		Namespace: getNamespace(d, meta),
-	}
+
 	aclToken, _, err := client.ACL().TokenRead(accessorID, qOpts)
 	if err != nil {
 		return err

--- a/consul/data_source_consul_agent_config.go
+++ b/consul/data_source_consul_agent_config.go
@@ -51,7 +51,8 @@ func dataSourceConsulAgentConfig() *schema.Resource {
 }
 
 func dataSourceConsulAgentConfigRead(d *schema.ResourceData, meta interface{}) error {
-	agentSelf, err := getClient(meta).Agent().Self()
+	client, _, _ := getClient(d, meta)
+	agentSelf, err := client.Agent().Self()
 	if err != nil {
 		return err
 	}

--- a/consul/data_source_consul_agent_self.go
+++ b/consul/data_source_consul_agent_self.go
@@ -503,7 +503,8 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 }
 
 func dataSourceConsulAgentSelfRead(d *schema.ResourceData, meta interface{}) error {
-	info, err := getClient(meta).Agent().Self()
+	client, _, _ := getClient(d, meta)
+	info, err := client.Agent().Self()
 	if err != nil {
 		return err
 	}

--- a/consul/data_source_consul_autopilot_health.go
+++ b/consul/data_source_consul_autopilot_health.go
@@ -12,70 +12,70 @@ func dataSourceConsulAutopilotHealth() *schema.Resource {
 		Read: dataSourceConsulAutopilotHealthRead,
 		Schema: map[string]*schema.Schema{
 			// Filters
-			"datacenter": &schema.Schema{
+			"datacenter": {
 				Optional: true,
 				Type:     schema.TypeString,
 			},
 
 			// Out parameters
-			"healthy": &schema.Schema{
+			"healthy": {
 				Computed: true,
 				Type:     schema.TypeBool,
 			},
-			"failure_tolerance": &schema.Schema{
+			"failure_tolerance": {
 				Computed: true,
 				Type:     schema.TypeInt,
 			},
-			"servers": &schema.Schema{
+			"servers": {
 				Computed: true,
 				Type:     schema.TypeList,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": &schema.Schema{
+						"id": {
 							Computed: true,
 							Type:     schema.TypeString,
 						},
-						"name": &schema.Schema{
+						"name": {
 							Computed: true,
 							Type:     schema.TypeString,
 						},
-						"address": &schema.Schema{
+						"address": {
 							Computed: true,
 							Type:     schema.TypeString,
 						},
-						"serf_status": &schema.Schema{
+						"serf_status": {
 							Computed: true,
 							Type:     schema.TypeString,
 						},
-						"version": &schema.Schema{
+						"version": {
 							Computed: true,
 							Type:     schema.TypeString,
 						},
-						"leader": &schema.Schema{
+						"leader": {
 							Computed: true,
 							Type:     schema.TypeBool,
 						},
-						"last_contact": &schema.Schema{
+						"last_contact": {
 							Computed: true,
 							Type:     schema.TypeString,
 						},
-						"last_term": &schema.Schema{
+						"last_term": {
 							Computed: true,
 							Type:     schema.TypeInt,
 						},
-						"last_index": &schema.Schema{
+						"last_index": {
 							Computed: true,
 							Type:     schema.TypeInt,
 						},
-						"healthy": &schema.Schema{
+						"healthy": {
 							Computed: true,
 							Type:     schema.TypeBool,
 						},
-						"voter": &schema.Schema{
+						"voter": {
 							Computed: true,
 							Type:     schema.TypeBool,
 						},
-						"stable_since": &schema.Schema{
+						"stable_since": {
 							Computed: true,
 							Type:     schema.TypeString,
 						},
@@ -87,23 +87,16 @@ func dataSourceConsulAutopilotHealth() *schema.Resource {
 }
 
 func dataSourceConsulAutopilotHealthRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 	operator := client.Operator()
+	getQueryOpts(qOpts, d, meta)
 
-	queryOpts, err := getQueryOpts(d, client, meta)
-	if err != nil {
-		return err
-	}
-	if datacenter, ok := d.GetOk("datacenter"); ok {
-		queryOpts.Datacenter = datacenter.(string)
-	}
-
-	health, err := operator.AutopilotServerHealth(queryOpts)
+	health, err := operator.AutopilotServerHealth(qOpts)
 	if err != nil {
 		return err
 	}
 	const idKeyFmt = "autopilot-health-%s"
-	d.SetId(fmt.Sprintf(idKeyFmt, queryOpts.Datacenter))
+	d.SetId(fmt.Sprintf(idKeyFmt, qOpts.Datacenter))
 
 	d.Set("healthy", health.Healthy)
 	d.Set("failure_tolerance", health.FailureTolerance)

--- a/consul/data_source_consul_key_prefix.go
+++ b/consul/data_source_consul_key_prefix.go
@@ -74,17 +74,7 @@ func dataSourceConsulKeyPrefix() *schema.Resource {
 }
 
 func dataSourceConsulKeyPrefixRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	namespace := getNamespace(d, meta)
-
-	kv := client.KV()
-	token := d.Get("token").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return err
-	}
-
-	keyClient := newKeyClient(kv, dc, token, namespace)
+	keyClient := newKeyClient(d, meta)
 
 	pathPrefix := d.Get("path_prefix").(string)
 
@@ -126,7 +116,7 @@ func dataSourceConsulKeyPrefixRead(d *schema.ResourceData, meta interface{}) err
 
 	// Store the datacenter on this resource, which can be helpful for reference
 	// in case it was read from the provider
-	d.Set("datacenter", dc)
+	d.Set("datacenter", keyClient.qOpts.Datacenter)
 	d.Set("path_prefix", pathPrefix)
 
 	d.SetId("-")

--- a/consul/data_source_consul_keys.go
+++ b/consul/data_source_consul_keys.go
@@ -61,16 +61,7 @@ func dataSourceConsulKeys() *schema.Resource {
 }
 
 func dataSourceConsulKeysRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	namespace := getNamespace(d, meta)
-	kv := client.KV()
-	token := d.Get("token").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return err
-	}
-
-	keyClient := newKeyClient(kv, dc, token, namespace)
+	keyClient := newKeyClient(d, meta)
 
 	vars := make(map[string]string)
 
@@ -96,7 +87,7 @@ func dataSourceConsulKeysRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Store the datacenter on this resource, which can be helpful for reference
 	// in case it was read from the provider
-	d.Set("datacenter", dc)
+	d.Set("datacenter", keyClient.qOpts.Datacenter)
 
 	d.SetId("-")
 

--- a/consul/data_source_consul_keys_test.go
+++ b/consul/data_source_consul_keys_test.go
@@ -47,6 +47,22 @@ func TestAccDataConsulKeys_namespaceEE(t *testing.T) {
 	})
 }
 
+func TestAccDataConsulKeys_datacenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccRemoteDatacenterPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataConsulKeysConfigDatacenter,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConsulKeysValue("data.consul_keys.dc1", "read", ""),
+					testAccCheckConsulKeysValue("data.consul_keys.dc2", "read", "dc2"),
+				),
+			},
+		},
+	})
+}
+
 const testAccDataConsulKeysConfig = `
 resource "consul_keys" "write" {
     datacenter = "dc1"
@@ -102,3 +118,31 @@ data "consul_keys" "read" {
     name = "read"
   }
 }`
+
+const testAccDataConsulKeysConfigDatacenter = `
+resource "consul_keys" "write" {
+    datacenter = "dc2"
+
+    key {
+        path   = "test/dc"
+        value  = "dc2"
+		delete = true
+    }
+}
+
+data "consul_keys" "dc1" {
+    key {
+        path = "test/dc"
+        name = "read"
+    }
+}
+
+data "consul_keys" "dc2" {
+    datacenter = consul_keys.write.datacenter
+
+    key {
+        path = "test/dc"
+        name = "read"
+    }
+}
+`

--- a/consul/data_source_consul_network_area_members.go
+++ b/consul/data_source_consul_network_area_members.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"fmt"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -84,22 +83,12 @@ func dataSourceConsulNetworkAreaMembers() *schema.Resource {
 }
 
 func datasourceConsulNetworkAreaMembersRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 	operator := client.Operator()
 
 	uuid := d.Get("uuid").(string)
 	d.SetId(fmt.Sprintf("consul-network-area-members-%s", uuid))
 
-	token := d.Get("token").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return err
-	}
-
-	qOpts := &consulapi.QueryOptions{
-		Token:      token,
-		Datacenter: dc,
-	}
 	members, _, err := operator.AreaMembers(uuid, qOpts)
 	if err != nil {
 		return fmt.Errorf("Failed to fetch the list of members: %v", err)

--- a/consul/data_source_consul_network_area_members_test.go
+++ b/consul/data_source_consul_network_area_members_test.go
@@ -42,6 +42,22 @@ func TestAccConsulNetworkAreaMembers_CommunityEdition(t *testing.T) {
 	})
 }
 
+func TestAccConsulNetworkAreaMembers_datacenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccRemoteDatacenterPreCheck(t)
+			skipTestOnConsulCommunityEdition(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConsulNetworkAreaMembers_datacenter,
+				Check:  resource.TestCheckResourceAttr("data.consul_network_area_members.test", "members.0.datacenter", "dc2"),
+			},
+		},
+	})
+}
+
 const testAccConsulNetworkAreaMembersBasic = `
 resource "consul_network_area" "test" {
 	peer_datacenter = "foo"
@@ -55,4 +71,16 @@ data "consul_network_area_members" "test" {
 const testAccConsulNetworkAreaMembers_CommunityEdition = `
 data "consul_network_area_members" "test" {
 	uuid = "1.2.3.4"
+}`
+
+const testAccConsulNetworkAreaMembers_datacenter = `
+resource "consul_network_area" "test" {
+	datacenter = "dc2"
+	peer_datacenter = "foo"
+	retry_join = ["1.2.3.4"]
+}
+
+data "consul_network_area_members" "test" {
+	datacenter = "dc2"
+	uuid = consul_network_area.test.id
 }`

--- a/consul/data_source_consul_network_segments.go
+++ b/consul/data_source_consul_network_segments.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"fmt"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -36,25 +35,15 @@ func dataSourceConsulNetworkSegments() *schema.Resource {
 }
 
 func dataSourceConsulNetworkSegmentsRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 	operator := client.Operator()
 
-	token := d.Get("token").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return err
-	}
-
-	qOpts := &consulapi.QueryOptions{
-		Token:      token,
-		Datacenter: dc,
-	}
 	segments, _, err := operator.SegmentList(qOpts)
 	if err != nil {
 		return fmt.Errorf("Failed to get segment list: %v", err)
 	}
 
-	d.SetId(fmt.Sprintf("consul-segments-%s", dc))
+	d.SetId(fmt.Sprintf("consul-segments-%s", qOpts.Datacenter))
 	if err := d.Set("segments", segments); err != nil {
 		return fmt.Errorf("Failed to set 'segments': %v", err)
 	}

--- a/consul/data_source_consul_network_segments_test.go
+++ b/consul/data_source_consul_network_segments_test.go
@@ -36,6 +36,28 @@ func TestAccConsulNetworkSegments_CommunityEdition(t *testing.T) {
 	})
 }
 
+func TestAccConsulNetworkSegments_datacenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccRemoteDatacenterPreCheck(t)
+			skipTestOnConsulCommunityEdition(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccConsulNetworkSegmentsDatacenter,
+				ExpectError: regexp.MustCompile("Failed to get segment list"),
+			},
+		},
+	})
+}
+
 const testAccConsulNetworkSegmentsBasic = `
 data "consul_network_segments" "test" {}
+`
+
+const testAccConsulNetworkSegmentsDatacenter = `
+data "consul_network_segments" "test" {
+	datacenter = "dc3"
+}
 `

--- a/consul/data_source_consul_nodes_test.go
+++ b/consul/data_source_consul_nodes_test.go
@@ -23,6 +23,7 @@ func TestAccDataConsulNodes_basic(t *testing.T) {
 		},
 	})
 }
+
 func TestAccDataConsulNodes_alias(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -32,6 +33,21 @@ func TestAccDataConsulNodes_alias(t *testing.T) {
 				Config: testAccDataConsulNodesAlias,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.consul_catalog_nodes.read", "nodes.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataConsulNodes_datacenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccRemoteDatacenterPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataConsulNodesDatacenter,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.consul_catalog_nodes.read", "nodes.#", "2"),
 				),
 			},
 		},
@@ -51,4 +67,18 @@ data "consul_nodes" "read" {
 `
 const testAccDataConsulNodesAlias = `
 data "consul_catalog_nodes" "read" {}
+`
+
+const testAccDataConsulNodesDatacenter = `
+resource "consul_node" "dc2" {
+	datacenter = "dc2"
+	name 	   = "dc2"
+	address    = "127.0.0.1"
+}
+
+data "consul_catalog_nodes" "read" {
+	query_options {
+		datacenter = consul_node.dc2.datacenter
+	}
+}
 `

--- a/consul/data_source_consul_service_health_test.go
+++ b/consul/data_source_consul_service_health_test.go
@@ -92,6 +92,19 @@ func TestAccDataConsulServiceHealthPassing(t *testing.T) {
 	})
 }
 
+func TestAccDataConsulServiceHealthDatacenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccRemoteDatacenterPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataConsulServiceHealthDatacenter,
+				Check:  testAccCheckDataSourceValue("data.consul_service_health.consul", "results.0.node.0.datacenter", "dc2"),
+			},
+		},
+	})
+}
+
 const testAccDataConsulServiceHealth = `
 data "consul_service_health" "consul" {
 	name   = "consul"
@@ -196,5 +209,12 @@ const testAccDataConsulServiceHealthPassingTrue = testAccDataConsulServiceHealth
 data "consul_service_health" "google" {
 	name     = "google"
 	// wait_for = "10s"
+}
+`
+
+const testAccDataConsulServiceHealthDatacenter = `
+data "consul_service_health" "consul" {
+	name       = "consul"
+	datacenter = "dc2"
 }
 `

--- a/consul/key_client.go
+++ b/consul/key_client.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 // keyClient is a wrapper around the upstream Consul client that is
@@ -15,20 +16,11 @@ type keyClient struct {
 	wOpts  *consulapi.WriteOptions
 }
 
-func newKeyClient(realClient *consulapi.KV, dc, token, namespace string) *keyClient {
-	qOpts := &consulapi.QueryOptions{
-		Datacenter: dc,
-		Token:      token,
-		Namespace:  namespace,
-	}
-	wOpts := &consulapi.WriteOptions{
-		Datacenter: dc,
-		Token:      token,
-		Namespace:  namespace,
-	}
+func newKeyClient(d *schema.ResourceData, meta interface{}) *keyClient {
+	client, qOpts, wOpts := getClient(d, meta)
 
 	return &keyClient{
-		client: realClient,
+		client: client.KV(),
 		qOpts:  qOpts,
 		wOpts:  wOpts,
 	}

--- a/consul/query_options.go
+++ b/consul/query_options.go
@@ -7,66 +7,55 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-const (
-	queryOptAllowStale        = "allow_stale"
-	queryOptDatacenter        = "datacenter"
-	queryOptNear              = "near"
-	queryOptNodeMeta          = "node_meta"
-	queryOptRequireConsistent = "require_consistent"
-	queryOptToken             = "token"
-	queryOptWaitIndex         = "wait_index"
-	queryOptWaitTime          = "wait_time"
-)
-
 func schemaQueryOpts() *schema.Schema {
 	return &schema.Schema{
 		Optional: true,
 		Type:     schema.TypeSet,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				queryOptAllowStale: {
+				"allow_stale": {
 					Optional: true,
 					Default:  true,
 					Type:     schema.TypeBool,
 				},
-				queryOptDatacenter: {
+				"datacenter": {
 					// Optional because we'll pull the default from the local agent if it's
 					// not specified, but we can query remote data centers as a result.
 					Optional: true,
 					Type:     schema.TypeString,
 				},
-				queryOptNear: {
+				"near": {
 					Optional: true,
 					Type:     schema.TypeString,
 				},
-				queryOptNodeMeta: {
+				"node_meta": {
 					Optional: true,
 					Type:     schema.TypeMap,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,
 					},
 				},
-				queryOptRequireConsistent: {
+				"require_consistent": {
 					Optional: true,
 					Default:  false,
 					Type:     schema.TypeBool,
 				},
-				queryOptToken: {
+				"token": {
 					Optional:  true,
 					Type:      schema.TypeString,
 					Sensitive: true,
 				},
-				queryOptWaitIndex: {
+				"wait_index": {
 					Optional: true,
 					Type:     schema.TypeInt,
-					ValidateFunc: makeValidationFunc(queryOptWaitIndex, []interface{}{
+					ValidateFunc: makeValidationFunc("wait_index", []interface{}{
 						validateIntMin(0),
 					}),
 				},
-				queryOptWaitTime: {
+				"wait_time": {
 					Optional: true,
 					Type:     schema.TypeString,
-					ValidateFunc: makeValidationFunc(queryOptWaitTime, []interface{}{
+					ValidateFunc: makeValidationFunc("wait_time", []interface{}{
 						validateDurationMin("0ns"),
 					}),
 				},
@@ -75,67 +64,57 @@ func schemaQueryOpts() *schema.Schema {
 	}
 }
 
-func getQueryOpts(d *schema.ResourceData, client *consulapi.Client, meta interface{}) (*consulapi.QueryOptions, error) {
-	queryOpts := &consulapi.QueryOptions{}
-
+func getQueryOpts(queryOpts *consulapi.QueryOptions, d *schema.ResourceData, meta interface{}) {
 	if filter, ok := d.GetOk("filter"); ok {
 		queryOpts.Filter = filter.(string)
 	}
 
-	if v, ok := d.GetOk(catalogNodesQueryOpts); ok {
+	if v, ok := d.GetOk("query_options"); ok {
 		for _, config := range v.(*schema.Set).List() {
 			queryOptions := config.(map[string]interface{})
-			if v, ok := queryOptions[queryOptAllowStale]; ok {
+			if v, ok := queryOptions["allow_stale"]; ok {
 				queryOpts.AllowStale = v.(bool)
 			}
 
-			if v, ok := queryOptions[queryOptDatacenter]; ok {
-				queryOpts.Datacenter = v.(string)
+			if v, ok := queryOptions["datacenter"]; ok {
+				if v.(string) != "" {
+					queryOpts.Datacenter = v.(string)
+				}
 			}
 
 			if v, ok := queryOptions["namespace"]; ok {
 				queryOpts.Namespace = v.(string)
 			}
 
-			if queryOpts.Datacenter == "" {
-				dc, err := getDC(d, client, meta)
-				if err != nil {
-					return nil, err
-				}
-				queryOpts.Datacenter = dc
-			}
-
-			if v, ok := queryOptions[queryOptNear]; ok {
+			if v, ok := queryOptions["near"]; ok {
 				queryOpts.Near = v.(string)
 			}
 
-			if v, ok := queryOptions[queryOptRequireConsistent]; ok {
+			if v, ok := queryOptions["require_consistent"]; ok {
 				queryOpts.RequireConsistent = v.(bool)
 			}
 
-			if v, ok := queryOptions[queryOptNodeMeta]; ok {
+			if v, ok := queryOptions["node_meta"]; ok {
 				m := v.(map[string]interface{})
-				nodeMetaMap := make(map[string]string, len(queryOptNodeMeta))
+				nodeMetaMap := make(map[string]string, len("node_meta"))
 				for s, t := range m {
 					nodeMetaMap[s] = t.(string)
 				}
 				queryOpts.NodeMeta = nodeMetaMap
 			}
 
-			if v, ok := queryOptions[queryOptToken]; ok {
+			if v, ok := queryOptions["token"]; ok {
 				queryOpts.Token = v.(string)
 			}
 
-			if v, ok := queryOptions[queryOptWaitIndex]; ok {
+			if v, ok := queryOptions["wait_index"]; ok {
 				queryOpts.WaitIndex = uint64(v.(int))
 			}
 
-			if v, ok := queryOptions[queryOptWaitTime]; ok {
+			if v, ok := queryOptions["wait_time"]; ok {
 				d, _ := time.ParseDuration(v.(string))
 				queryOpts.WaitTime = d
 			}
 		}
 	}
-
-	return queryOpts, nil
 }

--- a/consul/resource_consul_acl_auth_method.go
+++ b/consul/resource_consul_acl_auth_method.go
@@ -127,8 +127,8 @@ func resourceConsulACLAuthMethod() *schema.Resource {
 }
 
 func resourceConsulACLAuthMethodCreate(d *schema.ResourceData, meta interface{}) error {
-	ACL := getClient(meta).ACL()
-	wOpts := &consulapi.WriteOptions{}
+	client, _, wOpts := getClient(d, meta)
+	ACL := client.ACL()
 
 	authMethod, err := getAuthMethod(d, meta)
 	if err != nil {
@@ -143,11 +143,8 @@ func resourceConsulACLAuthMethodCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceConsulACLAuthMethodRead(d *schema.ResourceData, meta interface{}) error {
-	ACL := getClient(meta).ACL()
-	namespace := getNamespace(d, meta)
-	qOpts := &consulapi.QueryOptions{
-		Namespace: namespace,
-	}
+	client, qOpts, _ := getClient(d, meta)
+	ACL := client.ACL()
 
 	name := d.Get("name").(string)
 	authMethod, _, err := ACL.AuthMethodRead(name, qOpts)
@@ -219,8 +216,8 @@ func resourceConsulACLAuthMethodRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceConsulACLAuthMethodUpdate(d *schema.ResourceData, meta interface{}) error {
-	ACL := getClient(meta).ACL()
-	wOpts := &consulapi.WriteOptions{}
+	client, _, wOpts := getClient(d, meta)
+	ACL := client.ACL()
 
 	authMethod, err := getAuthMethod(d, meta)
 	if err != nil {
@@ -235,11 +232,8 @@ func resourceConsulACLAuthMethodUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceConsulACLAuthMethodDelete(d *schema.ResourceData, meta interface{}) error {
-	ACL := getClient(meta).ACL()
-	namespace := getNamespace(d, meta)
-	wOpts := &consulapi.WriteOptions{
-		Namespace: namespace,
-	}
+	client, _, wOpts := getClient(d, meta)
+	ACL := client.ACL()
 
 	authMethodName := d.Get("name").(string)
 	if _, err := ACL.AuthMethodDelete(authMethodName, wOpts); err != nil {
@@ -251,7 +245,7 @@ func resourceConsulACLAuthMethodDelete(d *schema.ResourceData, meta interface{})
 }
 
 func getAuthMethod(d *schema.ResourceData, meta interface{}) (*consulapi.ACLAuthMethod, error) {
-	namespace := getNamespace(d, meta)
+	_, qOpts, _ := getClient(d, meta)
 
 	var config map[string]interface{}
 	if c := d.Get("config_json").(string); c != "" {
@@ -270,7 +264,7 @@ func getAuthMethod(d *schema.ResourceData, meta interface{}) (*consulapi.ACLAuth
 		Type:          d.Get("type").(string),
 		Description:   d.Get("description").(string),
 		Config:        config,
-		Namespace:     namespace,
+		Namespace:     qOpts.Namespace,
 	}
 
 	if mtt, ok := d.GetOk("max_token_ttl"); ok {

--- a/consul/resource_consul_acl_auth_method_test.go
+++ b/consul/resource_consul_acl_auth_method_test.go
@@ -118,7 +118,7 @@ func TestAccConsulACLAuthMethod_namespaceEE(t *testing.T) {
 
 func testAuthMethodCACert(name, v string) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
-		ACL := getClient(testAccProvider.Meta()).ACL()
+		ACL := getTestClient(testAccProvider.Meta()).ACL()
 
 		authMethod, _, err := ACL.AuthMethodRead(name, nil)
 		if err != nil {
@@ -140,7 +140,7 @@ func testAuthMethodCACert(name, v string) func(s *terraform.State) error {
 }
 
 func testAuthMethodDestroy(s *terraform.State) error {
-	ACL := getClient(testAccProvider.Meta()).ACL()
+	ACL := getTestClient(testAccProvider.Meta()).ACL()
 	qOpts := &consulapi.QueryOptions{}
 
 	role, _, err := ACL.AuthMethodRead("minikube2", qOpts)

--- a/consul/resource_consul_acl_binding_rule.go
+++ b/consul/resource_consul_acl_binding_rule.go
@@ -56,8 +56,8 @@ func resourceConsulACLBindingRule() *schema.Resource {
 }
 
 func resourceConsulACLBindingRuleCreate(d *schema.ResourceData, meta interface{}) error {
-	ACL := getClient(meta).ACL()
-	wOpts := &consulapi.WriteOptions{}
+	client, _, wOpts := getClient(d, meta)
+	ACL := client.ACL()
 
 	rule := getBindingRule(d, meta)
 
@@ -72,11 +72,8 @@ func resourceConsulACLBindingRuleCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceConsulACLBindingRuleRead(d *schema.ResourceData, meta interface{}) error {
-	ACL := getClient(meta).ACL()
-	namespace := getNamespace(d, meta)
-	qOpts := &consulapi.QueryOptions{
-		Namespace: namespace,
-	}
+	client, qOpts, _ := getClient(d, meta)
+	ACL := client.ACL()
 
 	rule, _, err := ACL.BindingRuleRead(d.Id(), qOpts)
 	if err != nil {
@@ -107,8 +104,8 @@ func resourceConsulACLBindingRuleRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceConsulACLBindingRuleUpdate(d *schema.ResourceData, meta interface{}) error {
-	ACL := getClient(meta).ACL()
-	wOpts := &consulapi.WriteOptions{}
+	client, _, wOpts := getClient(d, meta)
+	ACL := client.ACL()
 
 	rule := getBindingRule(d, meta)
 
@@ -121,11 +118,8 @@ func resourceConsulACLBindingRuleUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceConsulACLBindingRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	ACL := getClient(meta).ACL()
-	namespace := getNamespace(d, meta)
-	wOpts := &consulapi.WriteOptions{
-		Namespace: namespace,
-	}
+	client, _, wOpts := getClient(d, meta)
+	ACL := client.ACL()
 
 	if _, err := ACL.BindingRuleDelete(d.Id(), wOpts); err != nil {
 		return fmt.Errorf("Failed to delete binding rule '%s': %v", d.Id(), err)
@@ -137,6 +131,7 @@ func resourceConsulACLBindingRuleDelete(d *schema.ResourceData, meta interface{}
 }
 
 func getBindingRule(d *schema.ResourceData, meta interface{}) *consulapi.ACLBindingRule {
+	_, _, wOpts := getClient(d, meta)
 	return &consulapi.ACLBindingRule{
 		ID:          d.Id(),
 		Description: d.Get("description").(string),
@@ -144,6 +139,6 @@ func getBindingRule(d *schema.ResourceData, meta interface{}) *consulapi.ACLBind
 		Selector:    d.Get("selector").(string),
 		BindName:    d.Get("bind_name").(string),
 		BindType:    consulapi.BindingRuleBindType(d.Get("bind_type").(string)),
-		Namespace:   getNamespace(d, meta),
+		Namespace:   wOpts.Namespace,
 	}
 }

--- a/consul/resource_consul_acl_binding_rule_test.go
+++ b/consul/resource_consul_acl_binding_rule_test.go
@@ -81,7 +81,7 @@ func TestAccConsulACLBindingRule_namespaceEE(t *testing.T) {
 }
 
 func testBindingRuleDestroy(s *terraform.State) error {
-	ACL := getClient(testAccProvider.Meta()).ACL()
+	ACL := getTestClient(testAccProvider.Meta()).ACL()
 	qOpts := &consulapi.QueryOptions{}
 
 	rules, _, err := ACL.BindingRuleList("minikube2", qOpts)

--- a/consul/resource_consul_acl_policy.go
+++ b/consul/resource_consul_acl_policy.go
@@ -52,7 +52,7 @@ func resourceConsulACLPolicy() *schema.Resource {
 }
 
 func resourceConsulACLPolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, _, wOpts := getClient(d, meta)
 
 	log.Printf("[DEBUG] Creating ACL policy")
 
@@ -60,7 +60,7 @@ func resourceConsulACLPolicyCreate(d *schema.ResourceData, meta interface{}) err
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
 		Rules:       d.Get("rules").(string),
-		Namespace:   getNamespace(d, meta),
+		Namespace:   wOpts.Namespace,
 	}
 
 	if v, ok := d.GetOk("datacenters"); ok {
@@ -72,7 +72,7 @@ func resourceConsulACLPolicyCreate(d *schema.ResourceData, meta interface{}) err
 		aclPolicy.Datacenters = s
 	}
 
-	policy, _, err := client.ACL().PolicyCreate(&aclPolicy, nil)
+	policy, _, err := client.ACL().PolicyCreate(&aclPolicy, wOpts)
 	if err != nil {
 		return fmt.Errorf("error creating ACL policy: %s", err)
 	}
@@ -85,10 +85,7 @@ func resourceConsulACLPolicyCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulACLPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	qOpts := &consulapi.QueryOptions{
-		Namespace: getNamespace(d, meta),
-	}
+	client, qOpts, _ := getClient(d, meta)
 
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL policy %q", id)
@@ -128,7 +125,7 @@ func resourceConsulACLPolicyRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulACLPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, _, wOpts := getClient(d, meta)
 
 	id := d.Id()
 	log.Printf("[DEBUG] Updating ACL policy %q", id)
@@ -138,7 +135,7 @@ func resourceConsulACLPolicyUpdate(d *schema.ResourceData, meta interface{}) err
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
 		Rules:       d.Get("rules").(string),
-		Namespace:   getNamespace(d, meta),
+		Namespace:   wOpts.Namespace,
 	}
 
 	if v, ok := d.GetOk("datacenters"); ok {
@@ -150,7 +147,7 @@ func resourceConsulACLPolicyUpdate(d *schema.ResourceData, meta interface{}) err
 		aclPolicy.Datacenters = s
 	}
 
-	_, _, err := client.ACL().PolicyUpdate(&aclPolicy, nil)
+	_, _, err := client.ACL().PolicyUpdate(&aclPolicy, wOpts)
 	if err != nil {
 		return fmt.Errorf("error updating ACL policy %q: %s", id, err)
 	}
@@ -160,10 +157,7 @@ func resourceConsulACLPolicyUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulACLPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	wOpts := &consulapi.WriteOptions{
-		Namespace: getNamespace(d, meta),
-	}
+	client, _, wOpts := getClient(d, meta)
 
 	id := d.Id()
 

--- a/consul/resource_consul_acl_policy_test.go
+++ b/consul/resource_consul_acl_policy_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func testAccCheckConsulACLPolicyDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+	client := getTestClient(testAccProvider.Meta())
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "consul_acl_policy" {

--- a/consul/resource_consul_acl_role_test.go
+++ b/consul/resource_consul_acl_role_test.go
@@ -101,7 +101,7 @@ func TestAccConsulACLRole_NamespaceEE(t *testing.T) {
 }
 
 func testRoleDestroy(s *terraform.State) error {
-	ACL := getClient(testAccProvider.Meta()).ACL()
+	ACL := getTestClient(testAccProvider.Meta()).ACL()
 	qOpts := &consulapi.QueryOptions{}
 
 	role, _, err := ACL.RoleReadByName("baz", qOpts)

--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -66,11 +66,7 @@ func resourceConsulACLToken() *schema.Resource {
 }
 
 func resourceConsulACLTokenCreate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	namespace := getNamespace(d, meta)
-	wOpts := &consulapi.WriteOptions{
-		Namespace: namespace,
-	}
+	client, _, wOpts := getClient(d, meta)
 
 	log.Printf("[DEBUG] Creating ACL token")
 
@@ -89,11 +85,7 @@ func resourceConsulACLTokenCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceConsulACLTokenRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	namespace := getNamespace(d, meta)
-	qOpts := &consulapi.QueryOptions{
-		Namespace: namespace,
-	}
+	client, qOpts, _ := getClient(d, meta)
 
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL token %q", id)
@@ -144,11 +136,7 @@ func resourceConsulACLTokenRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceConsulACLTokenUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	namespace := getNamespace(d, meta)
-	wOpts := &consulapi.WriteOptions{
-		Namespace: namespace,
-	}
+	client, _, wOpts := getClient(d, meta)
 
 	id := d.Id()
 	log.Printf("[DEBUG] Updating ACL token %q", id)
@@ -166,11 +154,7 @@ func resourceConsulACLTokenUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceConsulACLTokenDelete(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	namespace := getNamespace(d, meta)
-	wOpts := &consulapi.WriteOptions{
-		Namespace: namespace,
-	}
+	client, _, wOpts := getClient(d, meta)
 
 	id := d.Id()
 

--- a/consul/resource_consul_acl_token_policy_attachment.go
+++ b/consul/resource_consul_acl_token_policy_attachment.go
@@ -36,13 +36,13 @@ func resourceConsulACLTokenPolicyAttachment() *schema.Resource {
 }
 
 func resourceConsulACLTokenPolicyAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 
 	log.Printf("[DEBUG] Creating ACL token policy attachment")
 
 	tokenID := d.Get("token_id").(string)
 
-	aclToken, _, err := client.ACL().TokenRead(tokenID, nil)
+	aclToken, _, err := client.ACL().TokenRead(tokenID, qOpts)
 	if err != nil {
 		return fmt.Errorf("Token '%s' not found", tokenID)
 	}
@@ -73,7 +73,7 @@ func resourceConsulACLTokenPolicyAttachmentCreate(d *schema.ResourceData, meta i
 }
 
 func resourceConsulACLTokenPolicyAttachmentRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL token policy attachment '%q'", id)
@@ -83,7 +83,7 @@ func resourceConsulACLTokenPolicyAttachmentRead(d *schema.ResourceData, meta int
 		return fmt.Errorf("Invalid ACL token policy attachment id '%q'", id)
 	}
 
-	aclToken, _, err := client.ACL().TokenRead(tokenID, nil)
+	aclToken, _, err := client.ACL().TokenRead(tokenID, qOpts)
 	if err != nil {
 		if strings.Contains(err.Error(), "ACL not found") {
 			log.Printf("[WARN] ACL token not found, removing from state")
@@ -119,7 +119,7 @@ func resourceConsulACLTokenPolicyAttachmentRead(d *schema.ResourceData, meta int
 }
 
 func resourceConsulACLTokenPolicyAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, wOpts := getClient(d, meta)
 
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL token policy attachment '%q'", id)
@@ -129,7 +129,7 @@ func resourceConsulACLTokenPolicyAttachmentDelete(d *schema.ResourceData, meta i
 		return fmt.Errorf("Invalid ACL token policy attachment id '%q'", id)
 	}
 
-	aclToken, _, err := client.ACL().TokenRead(tokenID, nil)
+	aclToken, _, err := client.ACL().TokenRead(tokenID, qOpts)
 	if err != nil {
 		return fmt.Errorf("Token '%s' not found", tokenID)
 	}
@@ -141,7 +141,7 @@ func resourceConsulACLTokenPolicyAttachmentDelete(d *schema.ResourceData, meta i
 		}
 	}
 
-	_, _, err = client.ACL().TokenUpdate(aclToken, nil)
+	_, _, err = client.ACL().TokenUpdate(aclToken, wOpts)
 	if err != nil {
 		return fmt.Errorf("Error updating ACL token '%q' to set new policy attachment: '%s'", tokenID, err)
 	}

--- a/consul/resource_consul_acl_token_policy_attachment_test.go
+++ b/consul/resource_consul_acl_token_policy_attachment_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func testAccCheckConsulACLTokenPolicyAttachmentDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+	client := getTestClient(testAccProvider.Meta())
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "consul_acl_token_policy_attachment" {
@@ -42,7 +42,7 @@ func testAccCheckTokenPolicyID(s *terraform.State) error {
 		return fmt.Errorf("No token ID is set")
 	}
 
-	client := getClient(testAccProvider.Meta())
+	client := getTestClient(testAccProvider.Meta())
 	_, _, err := client.ACL().TokenRead(tokenID, nil)
 	if err != nil {
 		return fmt.Errorf("Unable to retrieve token %q", tokenID)

--- a/consul/resource_consul_acl_token_role_attachment.go
+++ b/consul/resource_consul_acl_token_role_attachment.go
@@ -36,13 +36,13 @@ func resourceConsulACLTokenRoleAttachment() *schema.Resource {
 }
 
 func resourceConsulACLTokenRoleAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, wOpts := getClient(d, meta)
 
 	log.Printf("[DEBUG] Creating ACL token role attachment")
 
 	tokenID := d.Get("token_id").(string)
 
-	aclToken, _, err := client.ACL().TokenRead(tokenID, nil)
+	aclToken, _, err := client.ACL().TokenRead(tokenID, qOpts)
 	if err != nil {
 		return fmt.Errorf("Token '%s' not found", tokenID)
 	}
@@ -58,7 +58,7 @@ func resourceConsulACLTokenRoleAttachmentCreate(d *schema.ResourceData, meta int
 		Name: roleName,
 	})
 
-	_, _, err = client.ACL().TokenUpdate(aclToken, nil)
+	_, _, err = client.ACL().TokenUpdate(aclToken, wOpts)
 	if err != nil {
 		return fmt.Errorf("Error updating ACL token '%q' to set new role attachment: '%s'", tokenID, err)
 	}
@@ -73,7 +73,7 @@ func resourceConsulACLTokenRoleAttachmentCreate(d *schema.ResourceData, meta int
 }
 
 func resourceConsulACLTokenRoleAttachmentRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL token role attachment '%q'", id)
@@ -83,7 +83,7 @@ func resourceConsulACLTokenRoleAttachmentRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Invalid ACL token role attachment id '%q'", id)
 	}
 
-	aclToken, _, err := client.ACL().TokenRead(tokenID, nil)
+	aclToken, _, err := client.ACL().TokenRead(tokenID, qOpts)
 	if err != nil {
 		if strings.Contains(err.Error(), "ACL not found") {
 			log.Printf("[WARN] ACL token not found, removing from state")
@@ -119,7 +119,7 @@ func resourceConsulACLTokenRoleAttachmentRead(d *schema.ResourceData, meta inter
 }
 
 func resourceConsulACLTokenRoleAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, wOpts := getClient(d, meta)
 
 	id := d.Id()
 	log.Printf("[DEBUG] Reading ACL token role attachment '%q'", id)
@@ -129,7 +129,7 @@ func resourceConsulACLTokenRoleAttachmentDelete(d *schema.ResourceData, meta int
 		return fmt.Errorf("Invalid ACL token role attachment id '%q'", id)
 	}
 
-	aclToken, _, err := client.ACL().TokenRead(tokenID, nil)
+	aclToken, _, err := client.ACL().TokenRead(tokenID, qOpts)
 	if err != nil {
 		return fmt.Errorf("Token '%s' not found", tokenID)
 	}
@@ -141,7 +141,7 @@ func resourceConsulACLTokenRoleAttachmentDelete(d *schema.ResourceData, meta int
 		}
 	}
 
-	_, _, err = client.ACL().TokenUpdate(aclToken, nil)
+	_, _, err = client.ACL().TokenUpdate(aclToken, wOpts)
 	if err != nil {
 		return fmt.Errorf("Error updating ACL token '%q' to set new role attachment: '%s'", tokenID, err)
 	}

--- a/consul/resource_consul_acl_token_role_attachment_test.go
+++ b/consul/resource_consul_acl_token_role_attachment_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func testAccCheckConsulACLTokenRoleAttachmentDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+	client := getTestClient(testAccProvider.Meta())
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "consul_acl_token_role_attachment" {
@@ -42,7 +42,7 @@ func testAccCheckTokenRoleName(s *terraform.State) error {
 		return fmt.Errorf("No token ID is set")
 	}
 
-	client := getClient(testAccProvider.Meta())
+	client := getTestClient(testAccProvider.Meta())
 	_, _, err := client.ACL().TokenRead(tokenID, nil)
 	if err != nil {
 		return fmt.Errorf("Unable to retrieve token %q", tokenID)

--- a/consul/resource_consul_acl_token_test.go
+++ b/consul/resource_consul_acl_token_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func testAccCheckConsulACLTokenDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+	client := getTestClient(testAccProvider.Meta())
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "consul_acl_token" {

--- a/consul/resource_consul_agent_service.go
+++ b/consul/resource_consul_agent_service.go
@@ -45,7 +45,7 @@ func resourceConsulAgentService() *schema.Resource {
 }
 
 func resourceConsulAgentServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, _, _ := getClient(d, meta)
 	agent := client.Agent()
 
 	name := d.Get("name").(string)
@@ -94,7 +94,7 @@ func resourceConsulAgentServiceCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceConsulAgentServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, _, _ := getClient(d, meta)
 	agent := client.Agent()
 
 	name := d.Get("name").(string)
@@ -120,7 +120,7 @@ func resourceConsulAgentServiceRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceConsulAgentServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, _, _ := getClient(d, meta)
 	catalog := client.Agent()
 
 	id := d.Id()

--- a/consul/resource_consul_agent_service_test.go
+++ b/consul/resource_consul_agent_service_test.go
@@ -32,7 +32,7 @@ func TestAccConsulAgentService_basic(t *testing.T) {
 }
 
 func testAccCheckConsulAgentServiceDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+	client := getTestClient(testAccProvider.Meta())
 	agent := client.Agent()
 	services, err := agent.Services()
 	if err != nil {
@@ -47,7 +47,7 @@ func testAccCheckConsulAgentServiceDestroy(s *terraform.State) error {
 
 func testAccCheckConsulAgentServiceExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := getClient(testAccProvider.Meta())
+		client := getTestClient(testAccProvider.Meta())
 		agent := client.Agent()
 		services, err := agent.Services()
 		if err != nil {

--- a/consul/resource_consul_catalog_entry_test.go
+++ b/consul/resource_consul_catalog_entry_test.go
@@ -64,7 +64,7 @@ func TestAccConsulCatalogEntry_extremove(t *testing.T) {
 }
 
 func testAccCheckConsulCatalogEntryDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+	client := getTestClient(testAccProvider.Meta())
 	catalog := client.Catalog()
 	qOpts := consulapi.QueryOptions{}
 	services, _, err := catalog.Services(&qOpts)
@@ -80,7 +80,7 @@ func testAccCheckConsulCatalogEntryDestroy(s *terraform.State) error {
 
 func testAccCheckConsulCatalogEntryDeregister(node string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := getClient(testAccProvider.Meta())
+		client := getTestClient(testAccProvider.Meta())
 		catalog := client.Catalog()
 		wOpts := consulapi.WriteOptions{}
 
@@ -107,7 +107,7 @@ func testAccCheckConsulCatalogEntryDeregister(node string) resource.TestCheckFun
 
 func testAccCheckConsulCatalogEntryExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := getClient(testAccProvider.Meta())
+		client := getTestClient(testAccProvider.Meta())
 		catalog := client.Catalog()
 		qOpts := consulapi.QueryOptions{}
 		services, _, err := catalog.Services(&qOpts)

--- a/consul/resource_consul_certificate_authority.go
+++ b/consul/resource_consul_certificate_authority.go
@@ -34,14 +34,14 @@ func resourceConsulCertificateAuthority() *schema.Resource {
 }
 
 func resourceConsulCertificateAuthorityCreate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta).Connect()
+	client, _, wOpts := getClient(d, meta)
 
 	caConfig := &consulapi.CAConfig{
 		Provider: d.Get("connect_provider").(string),
 		Config:   d.Get("config").(map[string]interface{}),
 	}
 
-	if _, err := client.CASetConfig(caConfig, nil); err != nil {
+	if _, err := client.Connect().CASetConfig(caConfig, wOpts); err != nil {
 		return fmt.Errorf("Failed to set CA configuration: %v", err)
 	}
 
@@ -51,9 +51,9 @@ func resourceConsulCertificateAuthorityCreate(d *schema.ResourceData, meta inter
 }
 
 func resourceConsulCertificateAuthorityRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta).Connect()
+	client, qOpts, _ := getClient(d, meta)
 
-	conf, _, err := client.CAGetConfig(nil)
+	conf, _, err := client.Connect().CAGetConfig(qOpts)
 	if err != nil {
 		return fmt.Errorf("Failed to get CA configuration: %v", err)
 	}

--- a/consul/resource_consul_config_entry.go
+++ b/consul/resource_consul_config_entry.go
@@ -42,7 +42,8 @@ func resourceConsulConfigEntry() *schema.Resource {
 }
 
 func resourceConsulConfigEntryUpdate(d *schema.ResourceData, meta interface{}) error {
-	configEntries := getClient(meta).ConfigEntries()
+	client, _, wOpts := getClient(d, meta)
+	configEntries := client.ConfigEntries()
 
 	kind := d.Get("kind").(string)
 	name := d.Get("name").(string)
@@ -52,7 +53,6 @@ func resourceConsulConfigEntryUpdate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	wOpts := &consulapi.WriteOptions{}
 	if _, _, err := configEntries.Set(configEntry, wOpts); err != nil {
 		return fmt.Errorf("Failed to set '%s' config entry: %v", name, err)
 	}
@@ -73,11 +73,11 @@ to see what values are expected.`, configEntry.GetKind())
 }
 
 func resourceConsulConfigEntryRead(d *schema.ResourceData, meta interface{}) error {
-	configEntries := getClient(meta).ConfigEntries()
+	client, qOpts, _ := getClient(d, meta)
+	configEntries := client.ConfigEntries()
 	configKind := d.Get("kind").(string)
 	configName := d.Get("name").(string)
 
-	qOpts := &consulapi.QueryOptions{}
 	configEntry, _, err := configEntries.Get(configKind, configName, qOpts)
 	if err != nil {
 		if strings.Contains(err.Error(), "Unexpected response code: 404") {
@@ -101,11 +101,11 @@ func resourceConsulConfigEntryRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulConfigEntryDelete(d *schema.ResourceData, meta interface{}) error {
-	configEntries := getClient(meta).ConfigEntries()
+	client, _, wOpts := getClient(d, meta)
+	configEntries := client.ConfigEntries()
 	configKind := d.Get("kind").(string)
 	configName := d.Get("name").(string)
 
-	wOpts := &consulapi.WriteOptions{}
 	if _, err := configEntries.Delete(configKind, configName, wOpts); err != nil {
 		return fmt.Errorf("Failed to delete '%s' config entry: %#v", configName, err)
 	}

--- a/consul/resource_consul_intention_test.go
+++ b/consul/resource_consul_intention_test.go
@@ -91,7 +91,7 @@ func TestAccConsulIntention_namespaceEE(t *testing.T) {
 }
 
 func testAccCheckConsulIntentionDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+	client := getTestClient(testAccProvider.Meta())
 
 	qOpts := consulapi.QueryOptions{}
 	intentions, _, err := client.Connect().Intentions(&qOpts)
@@ -108,7 +108,7 @@ func testAccCheckConsulIntentionDestroy(s *terraform.State) error {
 
 func testAccRemoveConsulIntention(t *testing.T) func() {
 	return func() {
-		client := getClient(testAccProvider.Meta())
+		client := getTestClient(testAccProvider.Meta())
 		connect := client.Connect()
 		qOpts := &consulapi.QueryOptions{}
 		iM := &consulapi.IntentionMatch{

--- a/consul/resource_consul_key_prefix.go
+++ b/consul/resource_consul_key_prefix.go
@@ -83,16 +83,7 @@ func resourceConsulKeyPrefix() *schema.Resource {
 }
 
 func resourceConsulKeyPrefixCreate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	namespace := getNamespace(d, meta)
-	kv := client.KV()
-	token := d.Get("token").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return err
-	}
-
-	keyClient := newKeyClient(kv, dc, token, namespace)
+	keyClient := newKeyClient(d, meta)
 
 	type subKey struct {
 		value string
@@ -145,7 +136,7 @@ func resourceConsulKeyPrefixCreate(d *schema.ResourceData, meta interface{}) err
 
 	// Store the datacenter on this resource, which can be helpful for reference
 	// in case it was read from the provider
-	d.Set("datacenter", dc)
+	d.Set("datacenter", keyClient.qOpts.Datacenter)
 
 	// Now we can just write in all the initial values, since we can expect
 	// that nothing should need deleting yet, as long as there isn't some
@@ -163,16 +154,7 @@ func resourceConsulKeyPrefixCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulKeyPrefixUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	namespace := getNamespace(d, meta)
-	kv := client.KV()
-	token := d.Get("token").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return err
-	}
-
-	keyClient := newKeyClient(kv, dc, token, namespace)
+	keyClient := newKeyClient(d, meta)
 
 	pathPrefix := d.Id()
 
@@ -270,22 +252,13 @@ func resourceConsulKeyPrefixUpdate(d *schema.ResourceData, meta interface{}) err
 
 	// Store the datacenter on this resource, which can be helpful for reference
 	// in case it was read from the provider
-	d.Set("datacenter", dc)
+	d.Set("datacenter", keyClient.qOpts.Datacenter)
 
 	return nil
 }
 
 func resourceConsulKeyPrefixRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	namespace := getNamespace(d, meta)
-	kv := client.KV()
-	token := d.Get("token").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return err
-	}
-
-	keyClient := newKeyClient(kv, dc, token, namespace)
+	keyClient := newKeyClient(d, meta)
 
 	pathPrefix := d.Id()
 
@@ -336,7 +309,7 @@ func resourceConsulKeyPrefixRead(d *schema.ResourceData, meta interface{}) error
 
 	// Store the datacenter on this resource, which can be helpful for reference
 	// in case it was read from the provider
-	if err := d.Set("datacenter", dc); err != nil {
+	if err := d.Set("datacenter", keyClient.qOpts.Datacenter); err != nil {
 		return fmt.Errorf("failed to set 'datacenter': %v", err)
 	}
 
@@ -344,22 +317,13 @@ func resourceConsulKeyPrefixRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulKeyPrefixDelete(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	namespace := getNamespace(d, meta)
-	kv := client.KV()
-	token := d.Get("token").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return err
-	}
-
-	keyClient := newKeyClient(kv, dc, token, namespace)
+	keyClient := newKeyClient(d, meta)
 
 	pathPrefix := d.Id()
 
 	// Delete everything under our prefix, since the entire set of keys under
 	// the given prefix is considered to be managed exclusively by Terraform.
-	err = keyClient.DeleteUnderPrefix(pathPrefix)
+	err := keyClient.DeleteUnderPrefix(pathPrefix)
 	if err != nil {
 		return err
 	}

--- a/consul/resource_consul_key_prefix_test.go
+++ b/consul/resource_consul_key_prefix_test.go
@@ -160,8 +160,21 @@ func TestAccConsulKeyPrefix_deleted(t *testing.T) {
 	})
 }
 
+func TestAccConsulKeyPrefix_datacenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccRemoteDatacenterPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConsulKeyPrefixConfig_datacenter,
+				Check:  testAccCheckConsulKeysDatacenter,
+			},
+		},
+	})
+}
+
 func testAccCheckConsulKeyPrefixDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+	client := getTestClient(testAccProvider.Meta())
 	kv := client.KV()
 	opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 	pair, _, err := kv.Get("test/set", opts)
@@ -177,7 +190,7 @@ func testAccCheckConsulKeyPrefixDestroy(s *terraform.State) error {
 func testAccCheckConsulKeyPrefixKeyAbsent(name string) resource.TestCheckFunc {
 	fullName := "prefix_test/" + name
 	return func(s *terraform.State) error {
-		client := getClient(testAccProvider.Meta())
+		client := getTestClient(testAccProvider.Meta())
 		kv := client.KV()
 		opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 		pair, _, err := kv.Get(fullName, opts)
@@ -196,7 +209,7 @@ func testAccCheckConsulKeyPrefixKeyAbsent(name string) resource.TestCheckFunc {
 func testAccAddConsulKeyPrefixRogue(name, value string) resource.TestCheckFunc {
 	fullName := "prefix_test/" + name
 	return func(s *terraform.State) error {
-		client := getClient(testAccProvider.Meta())
+		client := getTestClient(testAccProvider.Meta())
 		kv := client.KV()
 		opts := &consulapi.WriteOptions{Datacenter: "dc1"}
 		pair := &consulapi.KVPair{
@@ -212,7 +225,7 @@ func testAccAddConsulKeyPrefixRogue(name, value string) resource.TestCheckFunc {
 // It removes the prefix_test "folder" (all keys under this prefix)
 func testAccDeleteConsulKeyPrefix(t *testing.T, prefix string) func() {
 	return func() {
-		kv := getClient(testAccProvider.Meta()).KV()
+		kv := getTestClient(testAccProvider.Meta()).KV()
 		_, err := kv.DeleteTree(prefix, &consulapi.WriteOptions{Datacenter: "dc1"})
 		if err != nil {
 			t.Fatalf("failed to delete tree: %v", err)
@@ -224,7 +237,7 @@ func testAccDeleteConsulKeyPrefix(t *testing.T, prefix string) func() {
 // It removes one key in Consul
 func testAccDeleteConsulKey(t *testing.T, key string) func() {
 	return func() {
-		kv := getClient(testAccProvider.Meta()).KV()
+		kv := getTestClient(testAccProvider.Meta()).KV()
 		_, err := kv.Delete(key, &consulapi.WriteOptions{Datacenter: "dc1"})
 		if err != nil {
 			t.Fatalf("failed to delete key %q: %v", key, err)
@@ -235,7 +248,7 @@ func testAccDeleteConsulKey(t *testing.T, key string) func() {
 func testAccCheckConsulKeyPrefixKeyValue(name, value string, flags uint64) resource.TestCheckFunc {
 	fullName := "prefix_test/" + name
 	return func(s *terraform.State) error {
-		client := getClient(testAccProvider.Meta())
+		client := getTestClient(testAccProvider.Meta())
 		kv := client.KV()
 		opts := &consulapi.QueryOptions{Datacenter: "dc1"}
 		pair, _, err := kv.Get(fullName, opts)
@@ -362,6 +375,27 @@ resource "consul_key_prefix" "app" {
 	subkey {
 		path  = "second"
 		value = "plip"
+	}
+}
+`
+
+const testAccConsulKeyPrefixConfig_datacenter = `
+resource "consul_key_prefix" "dc1" {
+    path_prefix = "foo/"
+
+	subkey {
+		path  = "dc"
+		value = "dc1"
+	}
+}
+
+resource "consul_key_prefix" "dc2" {
+	datacenter = "dc2"
+    path_prefix = "foo/"
+
+	subkey {
+		path  = "dc"
+		value = "dc2"
 	}
 }
 `

--- a/consul/resource_consul_license.go
+++ b/consul/resource_consul_license.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"fmt"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -82,20 +81,12 @@ func resourceConsulLicense() *schema.Resource {
 }
 
 func resourceConsulLicenseCreate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, _, wOpts := getClient(d, meta)
 	operator := client.Operator()
 
 	license := d.Get("license").(string)
-	datacenter, err := getDC(d, client, meta)
-	if err != nil {
-		return fmt.Errorf("failed to read datacenter: %v", err)
-	}
 
-	wOpts := &consulapi.WriteOptions{
-		Datacenter: datacenter,
-	}
-
-	_, err = operator.LicensePut(license, wOpts)
+	_, err := operator.LicensePut(license, wOpts)
 	if err != nil {
 		return fmt.Errorf("failed to set license: %v", err)
 	}
@@ -104,17 +95,8 @@ func resourceConsulLicenseCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulLicenseRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 	operator := client.Operator()
-
-	datacenter, err := getDC(d, client, meta)
-	if err != nil {
-		return fmt.Errorf("failed to read datacenter: %v", err)
-	}
-
-	qOpts := &consulapi.QueryOptions{
-		Datacenter: datacenter,
-	}
 
 	licenseReply, err := operator.LicenseGet(qOpts)
 	if err != nil {
@@ -139,19 +121,10 @@ func resourceConsulLicenseRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceConsulLicenseDelete(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, _, wOpts := getClient(d, meta)
 	operator := client.Operator()
 
-	datacenter, err := getDC(d, client, meta)
-	if err != nil {
-		return fmt.Errorf("failed to read datacenter: %v", err)
-	}
-
-	wOpts := &consulapi.WriteOptions{
-		Datacenter: datacenter,
-	}
-
-	_, err = operator.LicenseReset(wOpts)
+	_, err := operator.LicenseReset(wOpts)
 	if err != nil {
 		return fmt.Errorf("failed to remove license: %v", err)
 	}

--- a/consul/resource_consul_license_test.go
+++ b/consul/resource_consul_license_test.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -56,31 +55,6 @@ func TestAccConsulLicense_CorrectLicense(t *testing.T) {
 			},
 		},
 	})
-}
-
-func serverIsConsulCommunityEdition(t *testing.T) bool {
-	client := getClient(testAccProvider.Meta())
-	self, err := client.Agent().Self()
-	if err != nil {
-		t.Fatalf("failed to get agent information: %v", err)
-	}
-	return !strings.HasSuffix(self["Config"]["Version"].(string), "+ent")
-}
-
-func skipTestOnConsulCommunityEdition(t *testing.T) {
-	testAccPreCheck(t)
-
-	if serverIsConsulCommunityEdition(t) {
-		t.Skip("Test skipped on Consul Community Edition. Use a Consul Enterprise server to run this test.")
-	}
-}
-
-func skipTestOnConsulEnterpriseEdition(t *testing.T) {
-	testAccPreCheck(t)
-
-	if !serverIsConsulCommunityEdition(t) {
-		t.Skip("Test skipped on Consul Enterprise Edition. Use a Consul Community server to run this test.")
-	}
 }
 
 const testAccConsulLicense = `

--- a/consul/resource_consul_namespace.go
+++ b/consul/resource_consul_namespace.go
@@ -46,11 +46,10 @@ func resourceConsulNamespace() *schema.Resource {
 }
 
 func resourceConsulNamespaceCreate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta).Namespaces()
-	wOpts := &consulapi.WriteOptions{}
+	client, _, wOpts := getClient(d, meta)
 
 	namespace := getNamespaceFromResourceData(d)
-	namespace, _, err := client.Create(namespace, wOpts)
+	namespace, _, err := client.Namespaces().Create(namespace, wOpts)
 	if err != nil {
 		return fmt.Errorf("failed to create namespace: %v", err)
 	}
@@ -59,11 +58,10 @@ func resourceConsulNamespaceCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulNamespaceRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta).Namespaces()
-	qOpts := &consulapi.QueryOptions{}
+	client, qOpts, _ := getClient(d, meta)
 	name := d.Id()
 
-	namespace, _, err := client.Read(name, qOpts)
+	namespace, _, err := client.Namespaces().Read(name, qOpts)
 	if namespace == nil {
 		d.SetId("")
 		return nil
@@ -97,11 +95,10 @@ func resourceConsulNamespaceRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceConsulNamespaceUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta).Namespaces()
-	wOpts := &consulapi.WriteOptions{}
+	client, _, wOpts := getClient(d, meta)
 
 	namespace := getNamespaceFromResourceData(d)
-	namespace, _, err := client.Update(namespace, wOpts)
+	namespace, _, err := client.Namespaces().Update(namespace, wOpts)
 	if err != nil {
 		return fmt.Errorf("failed to update namespace '%s': %v", namespace.Name, err)
 	}
@@ -110,10 +107,9 @@ func resourceConsulNamespaceUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta).Namespaces()
-	wOpts := &consulapi.WriteOptions{}
+	client, _, wOpts := getClient(d, meta)
 
-	_, err := client.Delete(d.Id(), wOpts)
+	_, err := client.Namespaces().Delete(d.Id(), wOpts)
 	if err != nil {
 		return fmt.Errorf("failed to delete namespace '%s': %v", d.Id(), err)
 	}

--- a/consul/resource_consul_network_area.go
+++ b/consul/resource_consul_network_area.go
@@ -50,7 +50,7 @@ func resourceConsulNetworkArea() *schema.Resource {
 }
 
 func resourceConsulNetworkAreaCreate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, _, wOpts := getClient(d, meta)
 	operator := client.Operator()
 
 	area := &consulapi.Area{
@@ -67,16 +67,6 @@ func resourceConsulNetworkAreaCreate(d *schema.ResourceData, meta interface{}) e
 		area.RetryJoin = s
 	}
 
-	token := d.Get("token").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return err
-	}
-
-	wOpts := &consulapi.WriteOptions{
-		Token:      token,
-		Datacenter: dc,
-	}
 	id, _, err := operator.AreaCreate(area, wOpts)
 	if err != nil {
 		return fmt.Errorf("Failed to create network area: %v", err)
@@ -87,21 +77,11 @@ func resourceConsulNetworkAreaCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceConsulNetworkAreaRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, qOpts, _ := getClient(d, meta)
 	operator := client.Operator()
 
 	id := d.Id()
 
-	token := d.Get("token").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return err
-	}
-
-	qOpts := &consulapi.QueryOptions{
-		Token:      token,
-		Datacenter: dc,
-	}
 	area, _, err := operator.AreaGet(id, qOpts)
 	if err != nil {
 		return fmt.Errorf("Failed to get %s area: %v", id, err)
@@ -134,7 +114,7 @@ func resourceConsulNetworkAreaRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceConsulNetworkAreaUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, _, wOpts := getClient(d, meta)
 	operator := client.Operator()
 
 	id := d.Id()
@@ -157,16 +137,6 @@ func resourceConsulNetworkAreaUpdate(d *schema.ResourceData, meta interface{}) e
 		area.RetryJoin = s
 	}
 
-	token := d.Get("token").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return err
-	}
-
-	wOpts := &consulapi.WriteOptions{
-		Token:      token,
-		Datacenter: dc,
-	}
 	_id, _, err := operator.AreaUpdate(id, area, wOpts)
 	if err != nil {
 		return fmt.Errorf("Failed to update '%s' network area: %v", id, err)
@@ -181,22 +151,12 @@ func resourceConsulNetworkAreaUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceConsulNetworkAreaDelete(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
+	client, _, wOpts := getClient(d, meta)
 	operator := client.Operator()
 
 	id := d.Id()
 
-	token := d.Get("token").(string)
-	dc, err := getDC(d, client, meta)
-	if err != nil {
-		return err
-	}
-
-	wOpts := &consulapi.WriteOptions{
-		Token:      token,
-		Datacenter: dc,
-	}
-	_, err = operator.AreaDelete(id, wOpts)
+	_, err := operator.AreaDelete(id, wOpts)
 	if err != nil {
 		return fmt.Errorf("Failed to delete '%s' network area: %v", err, id)
 	}

--- a/consul/resource_consul_network_area_test.go
+++ b/consul/resource_consul_network_area_test.go
@@ -59,8 +59,64 @@ func TestAccConsulNetworkArea_CommunityEdition(t *testing.T) {
 	})
 }
 
+func TestAccConsulNetworkArea_datacenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccRemoteDatacenterPreCheck(t)
+			skipTestOnConsulCommunityEdition(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccConsulNetworkAreaCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConsulNetworkAreaDatacenter,
+				Check: func(s *terraform.State) error {
+					test := func(dc, peer string) error {
+						c := getTestClient(testAccProvider.Meta()).Operator()
+						opts := &consulapi.QueryOptions{
+							Datacenter: dc,
+						}
+						area, _, err := c.AreaList(opts)
+						if err != nil {
+							return err
+						}
+						if len(area) != 1 {
+							return fmt.Errorf("wrong number of network area: %#v", area)
+						}
+						if area[0].PeerDatacenter != peer {
+							return fmt.Errorf("unexpected peer: %s", area[0].PeerDatacenter)
+						}
+						return nil
+					}
+					if err := test("dc1", "dc2"); err != nil {
+						return err
+					}
+					return test("dc2", "dc1")
+				},
+			},
+			{
+				Config: testAccConsulNetworkAreaBasic_update1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_network_area.test", "peer_datacenter", "foo"),
+					resource.TestCheckResourceAttr("consul_network_area.test", "use_tls", "true"),
+					resource.TestCheckResourceAttr("consul_network_area.test", "retry_join.#", "1"),
+					resource.TestCheckResourceAttr("consul_network_area.test", "retry_join.0", "1.2.3.4"),
+				),
+			},
+			{
+				Config: testAccConsulNetworkAreaBasic_update2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_network_area.test", "peer_datacenter", "bar"),
+					resource.TestCheckResourceAttr("consul_network_area.test", "use_tls", "true"),
+					resource.TestCheckResourceAttr("consul_network_area.test", "retry_join.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccConsulNetworkAreaCheckDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+	client := getTestClient(testAccProvider.Meta())
 	operator := client.Operator()
 
 	qOpts := &consulapi.QueryOptions{}
@@ -98,5 +154,18 @@ resource "consul_network_area" "test" {
 	retry_join = []
 
 	use_tls = true
+}
+`
+
+const testAccConsulNetworkAreaDatacenter = `
+resource "consul_network_area" "dc1" {
+	peer_datacenter = "dc2"
+	retry_join = []
+}
+
+resource "consul_network_area" "dc2" {
+	datacenter      = "dc2"
+	peer_datacenter = "dc1"
+	retry_join = []
 }
 `

--- a/consul/resource_consul_prepared_query.go
+++ b/consul/resource_consul_prepared_query.go
@@ -146,15 +146,10 @@ func resourceConsulPreparedQuery() *schema.Resource {
 }
 
 func resourceConsulPreparedQueryCreate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	wo := &consulapi.WriteOptions{
-		Datacenter: d.Get("datacenter").(string),
-		Token:      d.Get("token").(string),
-	}
-
+	client, _, wOpts := getClient(d, meta)
 	pq := preparedQueryDefinitionFromResourceData(d)
 
-	id, _, err := client.PreparedQuery().Create(pq, wo)
+	id, _, err := client.PreparedQuery().Create(pq, wOpts)
 	if err != nil {
 		return err
 	}
@@ -164,15 +159,10 @@ func resourceConsulPreparedQueryCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceConsulPreparedQueryUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	wo := &consulapi.WriteOptions{
-		Datacenter: d.Get("datacenter").(string),
-		Token:      d.Get("token").(string),
-	}
-
+	client, _, wOpts := getClient(d, meta)
 	pq := preparedQueryDefinitionFromResourceData(d)
 
-	if _, err := client.PreparedQuery().Update(pq, wo); err != nil {
+	if _, err := client.PreparedQuery().Update(pq, wOpts); err != nil {
 		return err
 	}
 
@@ -180,13 +170,9 @@ func resourceConsulPreparedQueryUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceConsulPreparedQueryRead(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	qo := &consulapi.QueryOptions{
-		Datacenter: d.Get("datacenter").(string),
-		Token:      d.Get("token").(string),
-	}
+	client, qOpts, _ := getClient(d, meta)
 
-	queries, _, err := client.PreparedQuery().Get(d.Id(), qo)
+	queries, _, err := client.PreparedQuery().Get(d.Id(), qOpts)
 	if err != nil {
 		// Check for a 404/not found, these are returned as errors.
 		if strings.Contains(err.Error(), "not found") {
@@ -290,13 +276,9 @@ func resourceConsulPreparedQueryRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceConsulPreparedQueryDelete(d *schema.ResourceData, meta interface{}) error {
-	client := getClient(meta)
-	writeOpts := &consulapi.WriteOptions{
-		Datacenter: d.Get("datacenter").(string),
-		Token:      d.Get("token").(string),
-	}
+	client, _, wOpts := getClient(d, meta)
 
-	if _, err := client.PreparedQuery().Delete(d.Id(), writeOpts); err != nil {
+	if _, err := client.PreparedQuery().Delete(d.Id(), wOpts); err != nil {
 		return err
 	}
 

--- a/consul_test_dc2.hcl
+++ b/consul_test_dc2.hcl
@@ -1,4 +1,5 @@
 ui = true
+datacenter = "dc2"
 primary_datacenter = "dc1"
 
 limits = {
@@ -11,8 +12,15 @@ acl = {
     down_policy = "extend-cache"
 
     tokens = {
-        master = "master-token"
+        replication = "master-token"
     }
 }
 
-retry_join_wan = ["127.0.0.1:8307"]
+ports = {
+    dns = -1
+    grpc = -1
+    http = 8501
+    server = 8305
+    serf_lan = 8306
+    serf_wan = 8307
+}


### PR DESCRIPTION
This also adds test with multiple datacenters, we were not testing this
configuration until now. The tests are not run by default to not make
local development more complicated but are run in CI both with Consul
Community Edition and Consul Enterprise.

Closes https://github.com/hashicorp/terraform-provider-consul/issues/8