### PR TITLE
Handle interpolations properly in consul_acl_auth_method

### DIFF
--- a/consul/resource_consul_acl_auth_method.go
+++ b/consul/resource_consul_acl_auth_method.go
@@ -16,15 +16,6 @@ func resourceConsulACLAuthMethod() *schema.Resource {
 		Update: resourceConsulACLAuthMethodUpdate,
 		Delete: resourceConsulACLAuthMethodDelete,
 
-		CustomizeDiff: func(d *schema.ResourceDiff, meta interface{}) error {
-			new := d.Get("config").(map[string]interface{})
-			jsonNew := d.Get("config_json").(string)
-			if len(new) == 0 && jsonNew == "" {
-				return fmt.Errorf("One of 'config' or 'config_json' must be set")
-			}
-			return nil
-		},
-
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
@@ -255,6 +246,10 @@ func getAuthMethod(d *schema.ResourceData, meta interface{}) (*consulapi.ACLAuth
 		}
 	} else {
 		config = d.Get("config").(map[string]interface{})
+	}
+
+	if len(config) == 0 {
+		return nil, fmt.Errorf("One of 'config' or 'config_json' must be set")
 	}
 
 	authMethod := &consulapi.ACLAuthMethod{


### PR DESCRIPTION
Because CustomizeDiff is called early when not all values are known, we
cannot actually use it to check whether config or config_json is set.
This means that we have to delay checking this after the plan, when we
actually try to create or update it.

Closes https://github.com/hashicorp/terraform-provider-consul/issues/260