### PR TITLE
Adds implementation for consul_services.tags #270

### DIFF
--- a/consul/data_source_consul_services_test.go
+++ b/consul/data_source_consul_services_test.go
@@ -82,7 +82,10 @@ func TestAccDataConsulServices_datacenter(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataConsulCatalogServicesDatacenter,
-				Check:  testAccCheckDataSourceValue("data.consul_services.read", "services.%", "2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceValue("data.consul_services.read", "services.%", "2"),
+					testAccCheckDataSourceValue("data.consul_services.read", "tags.tag0", "test"),
+				),
 			},
 		},
 	})
@@ -140,6 +143,7 @@ resource "consul_service" "test" {
 	name       = "test"
 	node       = consul_node.test.name
 	port       = 80
+	tags       = ["tag0"]
 }
 
 data "consul_services" "read" {


### PR DESCRIPTION
Fixes #270.

Was not able to run automated tests because on OSX Consul fails due to too many open files.