### PR TITLE
docs: Add deprecation note for consul_intentions resource

### DIFF
--- a/website/docs/r/intention.html.markdown
+++ b/website/docs/r/intention.html.markdown
@@ -11,7 +11,13 @@ description: |-
 [Intentions](https://www.consul.io/docs/connect/intentions.html) are used to define
 rules for which services may connect to one another when using [Consul Connect](https://www.consul.io/docs/connect/index.html).
 
-It is appropriate to either reference existing services or specify non-existent services
+~> **NOTE:** This resource is appropriate for managing legacy intentions in
+Consul version 1.8 and earlier. As of Consul 1.9, intentions should be managed
+using the [`service-intentions`](https://www.consul.io/docs/connect/intentions)
+configuration entry. It is recommended to migrate from the `consul_intention`
+resource to `consul_config_entry` when running Consul 1.9 and later.
+
+It is appropriate to either reference existing services, or specify non-existent services
 that will be created in the future when creating intentions. This resource can be used
 in conjunction with the `consul_service` datasource when referencing services
 registered on nodes that have a running Consul agent.


### PR DESCRIPTION
Note that as of Consul 1.9 intentions should be managed using `consul_config_entry` instead of the `consul_intentions` resource.