### PR TITLE
Minor documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Terraform Provider
 ==================
 
-- Website: https://www.terraform.io
+- Website: <https://www.terraform.io>
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
@@ -15,8 +15,8 @@ This provider plugin is maintained by the Consul team at [HashiCorp](https://www
 Requirements
 ------------
 
--	[Terraform](https://www.terraform.io/downloads.html) >= 0.13.x
--	[Go](https://golang.org/doc/install) >= 1.15
+- [Terraform](https://www.terraform.io/downloads.html) >= 0.13.x
+- [Go](https://golang.org/doc/install) >= 1.15
 
 Building The Provider
 ---------------------
@@ -24,8 +24,9 @@ Building The Provider
 1. Clone the repository
 1. Enter the repository directory
 1. Build the provider using the Go `install` command:
+
 ```sh
-$ go install
+go install
 ```
 
 Developing the Provider
@@ -38,7 +39,7 @@ To compile the provider, run `go install`. This will build the provider and put 
 In order to test the provider, you can simply run `make test`.
 
 ```sh
-$ make test
+make test
 ```
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
@@ -77,28 +78,28 @@ If you have [Docker](https://docs.docker.com/install/) installed, you can
 run Consul with the following command:
 
 ```sh
-$ make test-serv
+make test-serv
 ```
 
 By default, this will use the latest version of Consul based on the latest
 image in the Docker repository. You can specify a version with the following:
 
 ```sh
-$ CONSUL_VERSION=1.0.1 make test-serv
+CONSUL_VERSION=1.0.1 make test-serv
 ```
 
 This command will run attached and will stop Consul when
-interrupted. Images will be cached locally by Docker so it is quicky to
+interrupted. Images will be cached locally by Docker so it is quickly to
 restart the server as necessary. This will expose Consul on the default
-adddress.
+address.
 
 Nightly acceptance tests are run against the `latest` tag of the Consul
 Docker image. To run the acceptance tests against a development
-version of Consul, you can [compile it](https://github.com/hashicorp/consul#developing-consul)
+version of Consul, you can [compile it](https://github.com/hashicorp/consul/blob/main/.github/CONTRIBUTING.md#building-consul)
 locally and then run it in development mode:
 
-```
-$ consul agent -dev
+```shell
+consul agent -dev
 ```
 
 It is also possible to run additional tests to test the provider with multiple

--- a/website/docs/d/acl_policy.html.markdown
+++ b/website/docs/d/acl_policy.html.markdown
@@ -3,7 +3,7 @@ layout: "consul"
 page_title: "Consul: consul_acl_policy"
 sidebar_current: "docs-consul-data-source-acl-policy"
 description: |-
-  Provides information about a Consul ACL Poliy.
+  Provides information about a Consul ACL Policy.
 ---
 
 # consul_acl_policy

--- a/website/docs/d/nodes.html.markdown
+++ b/website/docs/d/nodes.html.markdown
@@ -53,9 +53,9 @@ The `query_options` block supports the following:
 
 * `token` - (Optional) Specify the Consul ACL token to use when performing the
   request.  This defaults to the same API token configured by the `consul`
-  provider but may be overriden if necessary.
+  provider but may be overridden if necessary.
 
-* `wait_index` - (Optional) Index number used to enable blocking quereis.
+* `wait_index` - (Optional) Index number used to enable blocking queries.
 
 * `wait_time` - (Optional) Max time the client should wait for a blocking query
   to return.

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -61,9 +61,9 @@ The `query_options` block supports the following:
 
 * `token` - (Optional) Specify the Consul ACL token to use when performing the
   request.  This defaults to the same API token configured by the `consul`
-  provider but may be overriden if necessary.
+  provider but may be overridden if necessary.
 
-* `wait_index` - (Optional) Index number used to enable blocking quereis.
+* `wait_index` - (Optional) Index number used to enable blocking queries.
 
 * `wait_time` - (Optional) Max time the client should wait for a blocking query
   to return.

--- a/website/docs/d/services.html.markdown
+++ b/website/docs/d/services.html.markdown
@@ -56,9 +56,9 @@ The `query_options` block supports the following:
 
 * `token` - (Optional) Specify the Consul ACL token to use when performing the
   request.  This defaults to the same API token configured by the `consul`
-  provider but may be overriden if necessary.
+  provider but may be overridden if necessary.
 
-* `wait_index` - (Optional) Index number used to enable blocking quereis.
+* `wait_index` - (Optional) Index number used to enable blocking queries.
 
 * `wait_time` - (Optional) Max time the client should wait for a blocking query
   to return.

--- a/website/docs/guides/upgrading.html.markdown
+++ b/website/docs/guides/upgrading.html.markdown
@@ -47,12 +47,12 @@ resource "consul_config_entry" "database" {
 
 ### Changes to consul_service
 
-The `external` attribute introduced in 2.3.0 has been deprecated and does not
-update the associated Consul Node meta information anymore. The same functionality
-can be done by setting the meta attribute on the `consul_node` resource:
+The `external` attribute introduced in 2.3.0 has been deprecated and no longer
+updates the associated Consul Node meta information. The same functionality
+can be achieved by setting the meta attribute on the `consul_node` resource:
 
 ``` terraform
-# This was working in 2.3.0
+# (Deprecated) External service configuration in 2.3.0
 resource "consul_node" "compute" {
   name    = "compute-example"
   address = "www.hashicorptest.com"
@@ -66,7 +66,7 @@ resource "consul_service" "example1" {
   external = true
 }
 
-# This is working in 2.4.0
+# Updated configuration as of 2.4.0
 resource "consul_node" "compute" {
   name    = "compute-example"
   address = "www.hashicorptest.com"

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -8,10 +8,11 @@ description: |-
 
 # Consul Provider
 
-[Consul](https://www.consul.io) is a tool for service discovery, configuration
-and orchestration. The Consul provider exposes resources used to interact with a
+[Consul](https://www.consul.io) is a service networking platform which provides
+service discovery, service mesh, and application configuration capabilities.
+The Consul provider exposes resources used to interact with a
 Consul cluster. Configuration of the provider is optional, as it provides
-defaults for all arguments.
+reasonable defaults for all arguments.
 
 Use the navigation to the left to read about the available resources.
 

--- a/website/docs/r/acl_auth_method.markdown
+++ b/website/docs/r/acl_auth_method.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 * `config` - (Optional) The raw configuration for this ACL auth method. This
   attribute is deprecated and will be removed in a future version. `config_json`
   should be used instead.
-* `namespace` - (Optional, Enterprise Only) The namespace to create the policy within.
+* `namespace` - (Optional, Enterprise Only) The namespace in which to create the auth method.
 * `namespace_rule` - (Optional, Enterprise Only) A set of rules that control
   which namespace tokens created via this auth method will be created within.
 
@@ -92,6 +92,6 @@ The following attributes are exported:
   deprecated and will be removed in a future version. If the configuration is
   too complex to be represented as a map of strings it will be blank.
   `config_json` should be used instead.
-* `namespace` - (Enterprise Only) The namespace to create the policy within.
+* `namespace` - (Enterprise Only) The namespace in which to create the auth method.
 * `namespace_rule` - (Enterprise Only) A set of rules that control which
   namespace tokens created via this auth method will be created within.

--- a/website/docs/r/acl_token.html.markdown
+++ b/website/docs/r/acl_token.html.markdown
@@ -31,7 +31,7 @@ resource "consul_acl_token" "test" {
 }
 ```
 
-### Set explictly the `accessor_id`
+### Explicitly set the `accessor_id`
 
 ```hcl
 resource "random_uuid" "test" { }

--- a/website/docs/r/config_entry.markdown
+++ b/website/docs/r/config_entry.markdown
@@ -217,7 +217,7 @@ The following arguments are supported:
 
 * `kind` - (Required) The kind of configuration entry to register.
 
-* `name` - (Required) The name of the configuration entry being registred.
+* `name` - (Required) The name of the configuration entry being registered.
 
 * `namespace` - (Optional, Enterprise Only) The namespace to create the config entry within.
 

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -15,7 +15,7 @@ with a [local agent](https://www.consul.io/docs/agent/basics.html).
 
 -> **NOTE:** If a Consul agent is running on the node where this service is
 registered, it is not recommended to use this resource as the service will be
-removed during the next [anti-entropy synchronisation](https://www.consul.io/docs/architecture/anti-entropy).
+removed during the next [anti-entropy synchronization](https://www.consul.io/docs/architecture/anti-entropy).
 
 ## Example Usage
 
@@ -94,7 +94,7 @@ of the `name` attribute.
 * `port` - (Optional, int) The port of the service.
 
 * `checks` - (Optional, list of checks) Health-checks to register to monitor the
-  service. The list of attributes for each health-check is detailled below.
+  service. The list of attributes for each health-check is detailed below.
 
 * `tags` - (Optional, set of strings) A list of values that are opaque to Consul,
   but can be used to distinguish between services or nodes.


### PR DESCRIPTION
* Fix broken URL and markdownlint warnings in README
* Fix spelling errors in resource and data source docs
* Update Consul description on index page
* Fix erroneous reference to policy in auth method namespace param

I can squash some of these commits if you'd prefer to have a smaller changeset.