### PR TITLE
Add instructions for previewing doc changes

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,5 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
-WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=consul
 CONSUL_VERSION ?= "latest"
 CONSUL_IMAGE ?= "docker.mirror.hashicorp.services/consul:$(CONSUL_VERSION)"
@@ -51,12 +50,5 @@ test-serv: fmtcheck
 		-v $(PWD)/consul_test.hcl:/consul/config/consul_test.hcl:ro \
 		$(CONSUL_IMAGE)
 
-website:
-ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
-	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
-	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
-endif
-	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
-
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile test-serv website
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile test-serv
 

--- a/README.md
+++ b/README.md
@@ -111,3 +111,15 @@ $ export CONSUL_HTTP_ADDR=localhost:8500
 $ export CONSUL_HTTP_TOKEN=master-token
 $ TEST_REMOTE_DATACENTER=1 make testacc
 ```
+
+Documentation
+-----------------------
+
+Full, comprehensive documentation is available on the Terraform Registry:
+
+<https://registry.terraform.io/providers/hashicorp/consul/latest/docs>
+
+If you wish to contribute to the documentation, the source can be found in this
+repository under website/docs/. To preview documentation changes prior to
+submitting a pull request, please use the Terraform Registry's
+[doc preview](https://registry.terraform.io/tools/doc-preview) tool.


### PR DESCRIPTION
Add instructions to the README on how to properly preview changes to documentation now that provider docs have been moved from Terraform.io to the Terraform registry.

This commit also removes the website target from the Makefile since it is no longer needed.