### PR TITLE
Add a compatibility table in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ Maintainers
 
 This provider plugin is maintained by the Consul team at [HashiCorp](https://www.hashicorp.com/).
 
+Compatibility
+-------------
+
+The Consul Terraform provider uses features of the latest version of Consul and
+some resources may not be supported by older versions of Consul.
+
+The known compatibility between this provider and Consul is:
+
+| Terraform provider version | Consul version |
+| -------------------------- | -------------- |
+| 2.14.0                     | >= 1.10.0      |
+| 2.13.0                     | >= 1.10.0      |
+
+
 Requirements
 ------------
 
@@ -22,8 +36,8 @@ Building The Provider
 ---------------------
 
 1. Clone the repository
-1. Enter the repository directory
-1. Build the provider using the Go `install` command:
+2. Enter the repository directory
+3. Build the provider using the Go `install` command:
 
 ```sh
 go install

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This provider plugin is maintained by the Consul team at [HashiCorp](https://www
 Compatibility
 -------------
 
-The Consul Terraform provider uses features of the latest version of Consul and
-some resources may not be supported by older versions of Consul.
+The Consul Terraform provider uses features of the latest version of Consul.
+Some resources may not be supported by older versions of Consul.
 
 The known compatibility between this provider and Consul is:
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Building The Provider
 ---------------------
 
 1. Clone the repository
-2. Enter the repository directory
-3. Build the provider using the Go `install` command:
+1. Enter the repository directory
+1. Build the provider using the Go `install` command:
 
 ```sh
 go install


### PR DESCRIPTION
It was written that "This provider targets the latest version of Consul" but some
users got confusing errors. Until I can spend some time to improve the status quo
and have a test setup accross multiple versions of Consul and this provider I
will report what combinations work there.

Related to https://github.com/hashicorp/terraform-provider-consul/issues/282