### PR TITLE
Feat: add consul datacenters

### DIFF
--- a/consul/data_source_consul_datacenters.go
+++ b/consul/data_source_consul_datacenters.go
@@ -1,0 +1,37 @@
+package consul
+
+import (
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceConsulDatacenters() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceConsulDatacentersRead,
+		Schema: map[string]*schema.Schema{
+
+			// Out parameters
+			"datacenters": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceConsulDatacentersRead(d *schema.ResourceData, meta interface{}) error {
+	client, _, _ := getClient(d, meta)
+
+	datacenters, err := client.Catalog().Datacenters()
+	if err != nil {
+		return err
+	}
+
+	d.SetId("-")
+	if err := d.Set("datacenters", datacenters); err != nil {
+		return errwrap.Wrapf("Unable to list datacenters: {{err}}", err)
+	}
+
+	return nil
+}

--- a/consul/data_source_consul_datacenters.go
+++ b/consul/data_source_consul_datacenters.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -9,7 +8,6 @@ func dataSourceConsulDatacenters() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceConsulDatacentersRead,
 		Schema: map[string]*schema.Schema{
-
 			// Out parameters
 			"datacenters": {
 				Computed: true,
@@ -29,9 +27,8 @@ func dataSourceConsulDatacentersRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.SetId("-")
-	if err := d.Set("datacenters", datacenters); err != nil {
-		return errwrap.Wrapf("Unable to list datacenters: {{err}}", err)
-	}
+	sw := newStateWriter(d)
+	sw.set("datacenters", datacenters)
 
-	return nil
+	return sw.error()
 }

--- a/consul/data_source_consul_datacenters_test.go
+++ b/consul/data_source_consul_datacenters_test.go
@@ -14,6 +14,7 @@ func TestAccDataConsulDatacenters_basic(t *testing.T) {
 			{
 				Config: testAccDataConsulDatacentersConfig,
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceValue("data.consul_datacenters.read", "datacenters.#", "1"),
 					testAccCheckDataSourceValue("data.consul_datacenters.read", "datacenters.0", "dc1"),
 				),
 			},

--- a/consul/data_source_consul_datacenters_test.go
+++ b/consul/data_source_consul_datacenters_test.go
@@ -1,0 +1,26 @@
+package consul
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataConsulDatacenters_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataConsulDatacentersConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceValue("data.consul_datacenters.read", "datacenters.0", "dc1"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataConsulDatacentersConfig = `
+data "consul_datacenters" "read" {}
+`

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -150,6 +150,7 @@ func Provider() terraform.ResourceProvider {
 			"consul_acl_token_secret_id":  dataSourceConsulACLTokenSecretID(),
 			"consul_network_segments":     dataSourceConsulNetworkSegments(),
 			"consul_network_area_members": dataSourceConsulNetworkAreaMembers(),
+			"consul_datacenters":          dataSourceConsulDatacenters(),
 
 			// Aliases to limit the impact of rename of catalog
 			// datasources

--- a/website/docs/d/datacenters.html.markdown
+++ b/website/docs/d/datacenters.html.markdown
@@ -3,33 +3,50 @@ layout: "consul"
 page_title: "Consul: consul_datacenters"
 sidebar_current: "docs-consul-data-source-datacenters"
 description: |-
-  Provides a list of datacenters in a given Consul cluster
+  Provides the list of all known datacenters.
 ---
 
 # consul_datacenters
 
-The `consul_datacenters` data source returns a list of Consul datacenters that are
-available within the Consul cluster. 
+The `consul_datacenters` data source returns the list of all knwown Consul
+datacenters.
 
 ## Example Usage
 
 ```hcl
-data "consul_datacenters" "read-datacenters" {}
+data "consul_datacenters" "all" {}
 
-# Loop over all datacenters to create an entry in each
-resource "example_resource" "app" {
-  for_each = toset(data.consul_datacenters.read-datacenters.datacenters)
+# Register a prepared query in each of the datacenters
+resource "consul_prepared_query" "myapp-query" {
+  for_each = toset(data.consul_datacenters.all.datacenters)
 
-  # ...
+  name         = "myquery"
+  datacenter   = each.key
+  only_passing = true
+  near         = "_agent"
+
+  service = "myapp"
+  tags    = ["active", "!standby"]
+
+  failover {
+    nearest_n   = 3
+    datacenters = ["us-west1", "us-east-2", "asia-east1"]
+  }
+
+  dns {
+    ttl = "30s"
+  }
 }
 ```
 
 ## Argument Reference
 
-This data source does not support any arguments
+This data source has no arguments.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `datacenters` - A list of datacenters within the cluster
+* `datacenters` - The list of datacenters known. The datacenters will be sorted
+  in ascending order based on the estimated median round trip time from the server
+  to the servers in that datacenter.

--- a/website/docs/d/datacenters.html.markdown
+++ b/website/docs/d/datacenters.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "consul"
+page_title: "Consul: consul_datacenters"
+sidebar_current: "docs-consul-data-source-datacenters"
+description: |-
+  Provides a list of datacenters in a given Consul cluster
+---
+
+# consul_datacenters
+
+The `consul_datacenters` data source returns a list of Consul datacenters that are
+available within the Consul cluster. 
+
+## Example Usage
+
+```hcl
+data "consul_datacenters" "read-datacenters" {}
+
+# Loop over all datacenters to create an entry in each
+resource "example_resource" "app" {
+  for_each = toset(data.consul_datacenters.read-datacenters.datacenters)
+
+  # ...
+}
+```
+
+## Argument Reference
+
+This data source does not support any arguments
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `datacenters` - A list of datacenters within the cluster


### PR DESCRIPTION
This Pull request adds the `consul_datacenters` data source to the terraform-provider for consul.  This is my first Pull Request in Golang, so constructive criticism is welcome! I've added Docs and a test as well.

Thanks!