### PR TITLE
feat: create the Consul client as late as possible

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 // Config is configuration defined in the provider block
@@ -26,6 +27,7 @@ type Config struct {
 	InsecureHttps bool   `mapstructure:"insecure_https"`
 	Namespace     string `mapstructure:"namespace"`
 	client        *consulapi.Client
+	resourceData  *schema.ResourceData
 }
 
 // Client returns a new client for accessing consul.
@@ -77,7 +79,6 @@ func (c *Config) Client() (*consulapi.Client, error) {
 
 	if config.Transport.TLSClientConfig == nil {
 		tlsClientConfig, err := consulapi.SetupTLSConfig(&config.TLSConfig)
-
 		if err != nil {
 			return nil, fmt.Errorf("failed to create http client: %s", err)
 		}


### PR DESCRIPTION
The goal of this PR is to be able to use dynamic data in the configuration of the provider, such as the _address_ field coming from a data source. To achieve this, the actual creation of the Consul client must be delayed as much as possible.

We're losing some error catching (it'd need a much bigger PR), hence there is a attempt to decode the configuration and fails early whenever possible.