### PR TITLE
Fix handling of partition in consul_config_entry

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,6 @@ jobs:
       run: |
         curl -LO https://releases.hashicorp.com/consul/1.11.4/consul_1.11.4_linux_amd64.zip
         sudo unzip consul_1.11.4_linux_amd64.zip consul -d /usr/local/bin
-        make testacc TESTARGS="-count=1"
+        SKIP_REMOTE_DATACENTER_TESTS=1 make testacc TESTARGS="-count=1"
     - name: Run go vet
       run: make vet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.15.1 (Unreleased)
+
+BUG FIXES:
+
+* The support of Admin Partition has been fixed for `consul_config_entry`: a new `partition` argument is now present and should be used instead of setting `Partition` in `config_json`.
+
 ## 2.15.0 (March 21, 2022)
 
 CHANGES:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,13 +1,20 @@
-TEST?=$$(go list ./... |grep -v 'vendor')
+TEST?=$$(go list ./... | grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
-PKG_NAME=consul
-CONSUL_VERSION ?= "latest"
-CONSUL_IMAGE ?= "docker.mirror.hashicorp.services/consul:$(CONSUL_VERSION)"
+HOSTNAME=hashicorp.com
+NAMESPACE=hashicorp
+NAME=consul
+BINARY=terraform-provider-${NAME}
+VERSION=2.15.1
+OS_ARCH=darwin_amd64
 
 default: build
 
 build: fmtcheck
-	go install
+	go build -o ${BINARY}
+
+install: build
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1
@@ -38,7 +45,7 @@ errcheck:
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \
-		echo "  make test-compile TEST=./$(PKG_NAME)"; \
+		echo "  make test-compile TEST=./$(NAME)"; \
 		exit 1; \
 	fi
 	go test -c $(TEST) $(TESTARGS)

--- a/consul/data_source_consul_services_test.go
+++ b/consul/data_source_consul_services_test.go
@@ -90,6 +90,9 @@ func TestAccDataConsulServices_datacenter(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataConsulCatalogServicesDatacenter,
+			},
+			{
+				Config: testAccDataConsulCatalogServicesDatacenter,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceValue("data.consul_services.read", "services.%", "2"),
 					testAccCheckDataSourceValue("data.consul_services.read", "tags.tag0", "test"),

--- a/consul/resource_consul_config_entry_ee_test.go
+++ b/consul/resource_consul_config_entry_ee_test.go
@@ -1,0 +1,826 @@
+package consul
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccConsulConfigEntryEE_basic(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { skipTestOnConsulCommunityEdition(t) },
+		Providers: providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConsulConfigEntryEE_ServiceDefaults,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "name", "foo"),
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "kind", "service-defaults"),
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "config_json", "{\"Expose\":{},\"MeshGateway\":{},\"Protocol\":\"https\",\"TransparentProxy\":{}}"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_ServiceDefaultsPartition,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "name", "foo"),
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "kind", "service-defaults"),
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "namespace", "ns1"),
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "partition", "part1"),
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "config_json", "{\"Expose\":{},\"MeshGateway\":{},\"Protocol\":\"https\",\"TransparentProxy\":{}}"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_ProxyDefaults,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "name", "global"),
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "kind", "proxy-defaults"),
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "config_json", "{\"Config\":{\"foo\":\"bar\"},\"Expose\":{},\"MeshGateway\":{},\"TransparentProxy\":{}}"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_ServiceRouter,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.service_router", "name", "web"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_router", "kind", "service-router"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_router", "config_json", "{\"Routes\":[{\"Destination\":{\"Namespace\":\"default\",\"Partition\":\"default\",\"Service\":\"admin\"},\"Match\":{\"HTTP\":{\"PathPrefix\":\"/admin\"}}}]}"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_ServiceSplitter,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.service_splitter", "name", "web"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_splitter", "kind", "service-splitter"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_splitter", "config_json", "{\"Splits\":[{\"ServiceSubset\":\"v1\",\"Weight\":90},{\"ServiceSubset\":\"v2\",\"Weight\":10}]}"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_ServiceResolver,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.service_resolver", "name", "web"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_resolver", "kind", "service-resolver"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_resolver", "config_json", "{\"DefaultSubset\":\"v1\",\"Subsets\":{\"v1\":{\"Filter\":\"Service.Meta.version == v1\"},\"v2\":{\"Filter\":\"Service.Meta.version == v2\"}}}"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_IngressGateway,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.ingress_gateway", "name", "foo"),
+					resource.TestCheckResourceAttr("consul_config_entry.ingress_gateway", "kind", "ingress-gateway"),
+					resource.TestCheckResourceAttr("consul_config_entry.ingress_gateway", "config_json", "{\"Listeners\":[{\"Port\":8000,\"Protocol\":\"http\",\"Services\":[{\"Hosts\":null,\"Name\":\"*\",\"Namespace\":\"default\",\"Partition\":\"default\"}]}],\"TLS\":{\"Enabled\":true}}"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_TerminatingGateway,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.terminating_gateway", "name", "foo-egress"),
+					resource.TestCheckResourceAttr("consul_config_entry.terminating_gateway", "kind", "terminating-gateway"),
+					resource.TestCheckResourceAttr("consul_config_entry.terminating_gateway", "config_json", "{\"Services\":[{\"Name\":\"billing\",\"Namespace\":\"default\"}]}"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_ServiceConfigAdminPartition,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "name", "example_server"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "kind", "service-intentions"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "partition", "part2"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "namespace", "ns2"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "config_json", "{\"Sources\":[{\"Action\":\"allow\",\"Name\":\"example_client\",\"Namespace\":\"ns1\",\"Partition\":\"part1\",\"Precedence\":9,\"Type\":\"consul\"}]}"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_ServiceConfigL4,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "name", "api-service"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "kind", "service-intentions"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_ServiceConfigL7,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "name", "fort-knox"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "kind", "service-intentions"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_ServiceConfigL7b,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "name", "api"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "kind", "service-intentions"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_ServiceConfigL7gRPC,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "name", "billing"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "kind", "service-intentions"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_ServiceConfigL7Mixed,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "name", "api"),
+					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "kind", "service-intentions"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConsulConfigEntryEE_Namespace(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { skipTestOnConsulCommunityEdition(t) },
+		Providers: providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConsulConfigEntryEE_DefaultNamespace,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "name", "foo"),
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "namespace", "default"),
+					resource.TestCheckResourceAttr("consul_config_entry.foo", "kind", "service-defaults"),
+				),
+			},
+			{
+				Config: testAccConsulConfigEntryEE_Namespace,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.test_intentions", "name", "destination-service"),
+					resource.TestCheckResourceAttr("consul_config_entry.test_intentions", "namespace", "example"),
+					resource.TestCheckResourceAttr("consul_config_entry.test_intentions", "kind", "service-intentions"),
+					resource.TestCheckResourceAttr("consul_config_entry.test_intentions", "config_json", "{\"Meta\":{\"foo\":\"bar\"},\"Sources\":[{\"Action\":\"allow\",\"Name\":\"source-service\",\"Namespace\":\"example\",\"Partition\":\"default\",\"Precedence\":9,\"Type\":\"consul\"}]}"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConsulConfigEntryEE_ServicesExported(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { skipTestOnConsulCommunityEdition(t) },
+		Providers: providers,
+		Steps: []resource.TestStep{
+			{
+				Config: TestAccConsulConfigEntryEE_exportedServicesEE,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.exported_services", "name", "test"),
+					resource.TestCheckResourceAttr("consul_config_entry.exported_services", "kind", "exported-services"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConsulConfigEntryEE_Mesh(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { skipTestOnConsulCommunityEdition(t) },
+		Providers: providers,
+		Steps: []resource.TestStep{
+			{
+				Config: TestAccConsulConfigEntryEE_meshEE,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.mesh", "name", "mesh"),
+					resource.TestCheckResourceAttr("consul_config_entry.mesh", "kind", "mesh"),
+				),
+			},
+		},
+	})
+}
+
+const testAccConsulConfigEntryEE_ServiceDefaults = `
+resource "consul_config_entry" "foo" {
+	name = "foo"
+	kind = "service-defaults"
+
+	config_json = jsonencode({
+		MeshGateway      = {}
+		Protocol         = "https"
+		TransparentProxy = {}
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_ServiceDefaultsPartition = `
+resource "consul_admin_partition" "part1" {
+  name = "part1"
+}
+
+resource "consul_namespace" "ns1" {
+  name = "ns1"
+  partition = consul_admin_partition.part1.name
+}
+
+resource "consul_config_entry" "foo" {
+  name      = "foo"
+  kind      = "service-defaults"
+  namespace = consul_namespace.ns1.name
+  partition = consul_admin_partition.part1.name
+
+  config_json = jsonencode({
+    Expose           = {}
+    Protocol         = "https"
+    TransparentProxy = {}
+  })
+}
+`
+
+const testAccConsulConfigEntryEE_ProxyDefaults = `
+resource "consul_config_entry" "foo" {
+	name = "global"
+	kind = "proxy-defaults"
+
+	config_json = jsonencode({
+		Config = {
+			foo = "bar"
+		}
+		MeshGateway      = {}
+		TransparentProxy = {}
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_ServiceRouter = `
+resource "consul_config_entry" "web" {
+	name = "web"
+	kind = "service-defaults"
+
+	config_json = jsonencode({
+		Expose           = {}
+		MeshGateway      = {}
+		TransparentProxy = {}
+		Protocol         = "http"
+	})
+}
+
+resource "consul_config_entry" "admin_service_defaults" {
+	name = "admin"
+	kind = "service-defaults"
+
+	config_json = jsonencode({
+		Expose           = {}
+		MeshGateway      = {}
+		TransparentProxy = {}
+		Protocol         = "http"
+	})
+}
+
+resource "consul_config_entry" "service_router" {
+	name = consul_config_entry.web.name
+	kind = "service-router"
+
+	config_json = jsonencode({
+		Routes = [
+			{
+				Match = {
+					HTTP = {
+						PathPrefix = "/admin"
+					}
+				}
+
+				Destination = {
+					Namespace = "default"
+					Partition = "default"
+					Service   = consul_config_entry.admin_service_defaults.name
+				}
+			}
+			# NOTE: a default catch-all will send unmatched traffic to "web"
+		]
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_ServiceSplitter = `
+resource "consul_config_entry" "web" {
+	name = "web"
+	kind = "service-defaults"
+
+	config_json = jsonencode({
+		Protocol         = "http"
+		Expose           = {}
+		MeshGateway      = {}
+		TransparentProxy = {}
+	})
+}
+
+resource "consul_config_entry" "service_resolver" {
+	kind = "service-resolver"
+	name = consul_config_entry.web.name
+
+	config_json = jsonencode({
+		DefaultSubset = "v1"
+
+		Subsets = {
+			"v1" = {
+				Filter = "Service.Meta.version == v1"
+			}
+			"v2" = {
+				Filter = "Service.Meta.version == v2"
+			}
+		}
+	})
+}
+
+resource "consul_config_entry" "service_splitter" {
+	kind = "service-splitter"
+	name = consul_config_entry.service_resolver.name
+
+	config_json = jsonencode({
+		Splits = [
+			{
+				Weight         = 90
+				ServiceSubset = "v1"
+			},
+			{
+				Weight        = 10
+				ServiceSubset = "v2"
+			},
+		]
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_ServiceResolver = `
+resource "consul_config_entry" "web" {
+	name = "web"
+	kind = "service-defaults"
+
+	config_json = jsonencode({
+		Protocol         = "http"
+		Expose           = {}
+		MeshGateway      = {}
+		TransparentProxy = {}
+	})
+}
+
+resource "consul_config_entry" "service_resolver" {
+	kind = "service-resolver"
+	name = consul_config_entry.web.name
+
+	config_json = jsonencode({
+		DefaultSubset = "v1"
+
+		Subsets = {
+			"v1" = {
+				Filter = "Service.Meta.version == v1"
+			}
+			"v2" = {
+				Filter = "Service.Meta.version == v2"
+			}
+		}
+
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_IngressGateway = `
+resource "consul_config_entry" "ingress_gateway" {
+	name = "foo"
+	kind = "ingress-gateway"
+
+	config_json = jsonencode({
+		TLS = {
+			Enabled = true
+		}
+		Listeners = [{
+			Port      = 8000
+			Protocol  = "http"
+			Services = [{
+				Hosts = null
+				Name  = "*"
+				Namespace        = "default"
+				Partition        = "default"
+			}]
+		}]
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_TerminatingGateway = `
+resource "consul_config_entry" "terminating_gateway" {
+	name = "foo-egress"
+	kind = "terminating-gateway"
+
+	config_json = jsonencode({
+		Services = [{
+			Name = "billing"
+			Namespace: "default"
+		}]
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_ServiceConfigAdminPartition = `
+resource "consul_admin_partition" "part1" {
+  name = "part1"
+}
+
+resource "consul_admin_partition" "part2" {
+  name = "part2"
+}
+
+resource "consul_namespace" "ns1" {
+  name = "ns1"
+  partition = consul_admin_partition.part1.name
+}
+
+resource "consul_namespace" "ns2" {
+  name = "ns2"
+  partition = consul_admin_partition.part2.name
+}
+
+resource "consul_config_entry" "service_intentions" {
+  kind      = "service-intentions"
+  name      = "example_server"
+  namespace = consul_namespace.ns2.name
+  partition = consul_admin_partition.part2.name
+
+  config_json = jsonencode({
+    Sources = [{
+      Action     = "allow"
+      Name       = "example_client"
+      Namespace  = consul_namespace.ns1.name
+      Partition  = consul_admin_partition.part1.name
+      Precedence = 9
+      Type       = "consul"
+    }]
+  })
+}
+`
+
+const testAccConsulConfigEntryEE_ServiceConfigL4 = `
+resource "consul_config_entry" "service_intentions" {
+	name = "api-service"
+	kind = "service-intentions"
+
+	config_json = jsonencode({
+		Sources = [
+			{
+				Namespace  = "default"
+				Partition  = "default"
+				Action     = "allow"
+				Name       = "frontend-webapp"
+				Precedence = 9
+				Type       = "consul"
+			},
+            {
+				Namespace  = "default"
+				Partition  = "default"
+				Action     = "allow"
+				Name       = "nightly-cronjob"
+				Precedence = 9
+				Type       = "consul"
+			}
+		]
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_ServiceConfigL7 = `
+resource "consul_config_entry" "sd" {
+	name = "fort-knox"
+	kind = "service-defaults"
+
+	config_json = jsonencode({
+		Protocol         = "http"
+		Expose           = {}
+		MeshGateway      = {}
+		TransparentProxy = {}
+	})
+}
+
+resource "consul_config_entry" "service_intentions" {
+	name = consul_config_entry.sd.name
+	kind = "service-intentions"
+
+	config_json = jsonencode({
+		Sources = [
+			{
+				Namespace   = "default"
+				Partition   = "default"
+				Name        = "contractor-webapp"
+				Permissions = [
+					{
+						Action = "allow"
+						HTTP   = {
+							Methods   = ["GET", "HEAD"]
+							PathExact = "/healtz"
+						}
+					}
+				]
+				Precedence = 9
+				Type       = "consul"
+			},
+			{
+				Namespace  = "default"
+				Partition  = "default"
+				Name        = "admin-dashboard-webapp",
+				Permissions = [
+					{
+						Action = "deny",
+						HTTP = {
+							PathPrefix= "/debugz"
+						}
+					},
+					{
+						Action= "allow"
+						HTTP = {
+							PathPrefix= "/"
+						}
+					}
+				],
+				Precedence = 9
+				Type       = "consul"
+			}
+		]
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_ServiceConfigL7b = `
+resource "consul_config_entry" "sd" {
+	name = "api"
+	kind = "service-defaults"
+
+	config_json = jsonencode({
+		Protocol         = "http"
+		Expose           = {}
+		MeshGateway      = {}
+		TransparentProxy = {}
+	})
+}
+
+resource "consul_config_entry" "service_intentions" {
+	name = consul_config_entry.sd.name
+	kind = "service-intentions"
+
+	config_json = jsonencode({
+		Sources = [
+			{
+				Namespace   = "default"
+				Partition   = "default"
+				Name        = "admin-dashboard"
+				Permissions = [
+					{
+						Action = "allow"
+						HTTP = {
+							Methods    = ["GET", "PUT", "POST", "DELETE", "HEAD"]
+							PathPrefix = "/v2"
+						}
+					}
+				],
+				Precedence = 9
+				Type = "consul"
+			},
+			{
+				Namespace = "default"
+				Partition = "default"
+				Name      = "report-generator"
+				Permissions = [
+					{
+						Action = "allow"
+						HTTP = {
+							Methods = ["GET"]
+							PathPrefix = "/v2/widgets"
+						}
+					}
+				],
+				Precedence = 9,
+				Type = "consul"
+			}
+		]
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_ServiceConfigL7gRPC = `
+resource "consul_config_entry" "sd" {
+	name = "billing"
+	kind = "service-defaults"
+
+	config_json = jsonencode({
+		Protocol         = "grpc"
+		Expose           = {}
+		MeshGateway      = {}
+		TransparentProxy = {}
+	})
+}
+
+resource "consul_config_entry" "service_intentions" {
+	name = consul_config_entry.sd.name
+	kind = "service-intentions"
+
+	config_json = jsonencode({
+		Sources = [
+			{
+				Namespace  = "default"
+				Partition  = "default"
+				Name       = "frontend-web"
+				Permissions = [
+					{
+						Action = "deny"
+						HTTP = {
+							PathExact = "/mycompany.BillingService/IssueRefund"
+						}
+					},
+					{
+						Action = "allow"
+						HTTP = {
+							PathPrefix = "/mycompany.BillingService/"
+						}
+					}
+				],
+				Precedence = 9
+				Type = "consul"
+			},
+			{
+				Namespace  = "default"
+				Partition  = "default"
+				Name       = "support-portal"
+				Permissions = [
+					{
+						Action = "allow"
+						HTTP = {
+							PathPrefix = "/mycompany.BillingService/"
+						}
+					}
+				],
+				Precedence = 9
+				Type = "consul"
+			}
+		]
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_ServiceConfigL7Mixed = `
+resource "consul_config_entry" "sd" {
+	name = "api"
+	kind = "service-defaults"
+
+	config_json = jsonencode({
+		Protocol         = "grpc"
+		Expose           = {}
+		MeshGateway      = {}
+		TransparentProxy = {}
+	})
+}
+
+resource "consul_config_entry" "service_intentions" {
+	name = consul_config_entry.sd.name
+	kind = "service-intentions"
+
+	config_json = jsonencode({
+		Sources = [
+			{
+				Namespace  = "default"
+				Partition  = "default"
+				Action     = "deny"
+				Name       = "hackathon-project"
+				Precedence = 9
+				Type       = "consul"
+			},
+			{
+				Namespace  = "default"
+				Partition  = "default"
+				Action     = "allow"
+				Name       = "web"
+				Precedence = 9
+				Type       = "consul"
+			},
+			{
+				Namespace  = "default"
+				Partition  = "default"
+				Name = "nightly-reconciler"
+				Permissions = [
+					{
+						Action = "allow"
+						HTTP = {
+							Methods   = ["POST"]
+							PathExact = "/v1/reconcile-data"
+						}
+					}
+				]
+				Precedence = 9
+				Type       = "consul"
+			}
+		]
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_DefaultNamespace = `
+resource "consul_config_entry" "foo" {
+	name      = "foo"
+	kind      = "service-defaults"
+	namespace = "default"
+
+	config_json = jsonencode({
+		Expose           = {}
+		MeshGateway      = {}
+		TransparentProxy = {}
+		Protocol         = "https"
+	})
+}
+`
+
+const testAccConsulConfigEntryEE_Namespace = `
+resource "consul_namespace" "example_namespace" {
+	name = "example"
+	description = "Example namespace"
+}
+
+resource "consul_config_entry" "test_intentions" {
+	name = "destination-service"
+	kind = "service-intentions"
+	namespace = consul_namespace.example_namespace.name
+
+	config_json = jsonencode({
+		Sources = [
+		  {
+			Action     = "allow"
+			Name       = "source-service"
+			Namespace  = "example"
+			Partition  = "default"
+			Precedence = 9
+			Type       = "consul"
+		  }
+		]
+		Meta = {
+			foo = "bar"
+		}
+	  })
+}
+`
+
+const TestAccConsulConfigEntryEE_mesh = `
+`
+
+const TestAccConsulConfigEntryEE_exportedServicesCE = `
+resource "consul_config_entry" "exported_services" {
+	name = "test"
+	kind = "exported-services"
+
+	config_json = jsonencode({
+		Services = [{
+			Name = "test"
+			Namespace = "default"
+			Consumers = [{
+				Partition = "default"
+			}]
+		}]
+	})
+}
+`
+
+const TestAccConsulConfigEntryEE_exportedServicesEE = `
+resource "consul_admin_partition" "test" {
+	name = "test"
+}
+
+resource "consul_config_entry" "exported_services" {
+	name = "test"
+	kind = "exported-services"
+	partition = consul_admin_partition.test.name
+
+	config_json = jsonencode({
+		Services = [{
+			Name = "test"
+			Namespace = "default"
+			Consumers = [{
+				Partition = "default"
+			}]
+		}]
+	})
+}
+`
+
+const TestAccConsulConfigEntryEE_meshCE = `
+resource "consul_config_entry" "mesh" {
+	name = "mesh"
+	kind = "mesh"
+
+	config_json = jsonencode({
+		TransparentProxy = {
+			MeshDestinationsOnly = true
+		}
+	})
+}
+`
+
+const TestAccConsulConfigEntryEE_meshEE = `
+resource "consul_config_entry" "mesh" {
+	name = "mesh"
+	kind = "mesh"
+
+	config_json = jsonencode({
+		TransparentProxy = {
+			MeshDestinationsOnly = true
+		}
+	})
+}
+`

--- a/consul/resource_provider_test.go
+++ b/consul/resource_provider_test.go
@@ -287,6 +287,10 @@ func startTestServer(t *testing.T) (map[string]terraform.ResourceProvider, *cons
 }
 
 func startRemoteDatacenterTestServer(t *testing.T) (map[string]terraform.ResourceProvider, *consulapi.Client) {
+	if os.Getenv("SKIP_REMOTE_DATACENTER_TESTS") != "" {
+		t.Skip("Remote datacenter skipped because SKIP_REMOTE_DATACENTER_TESTS is set")
+	}
+
 	startServerWithConfig(
 		t,
 		`

--- a/consul/resource_provider_test.go
+++ b/consul/resource_provider_test.go
@@ -343,7 +343,7 @@ func startRemoteDatacenterTestServer(t *testing.T) (map[string]terraform.Resourc
 	)
 
 	providers, client := waitForService(t)
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		datacenters, err := client.Catalog().Datacenters()
 		if err == nil && len(datacenters) == 2 {
 			return providers, client

--- a/consul/resource_provider_test.go
+++ b/consul/resource_provider_test.go
@@ -246,12 +246,9 @@ func waitForService(t *testing.T) (map[string]terraform.ResourceProvider, *consu
 	}
 
 	var services []*consulapi.ServiceEntry
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		services, _, err = client.Health().Service("consul", "", true, nil)
-		if err == nil && len(services) == 1 {
-			// Once the service is up we have to wait for the info to be synced
-			time.Sleep(200 * time.Millisecond)
-
+		if err == nil && len(services) == 1 && len(services[0].Node.Meta) == 1 {
 			return map[string]terraform.ResourceProvider{
 				"consul": Provider(),
 			}, client

--- a/website/docs/r/config_entry.markdown
+++ b/website/docs/r/config_entry.markdown
@@ -238,12 +238,11 @@ resource "consul_config_entry" "exported_services" {
 
 ```hcl
 resource "consul_config_entry" "mesh" {
-	name = "mesh"
-	kind = "mesh"
+	name      = "mesh"
+	kind      = "mesh"
+  partition = "default"
 
 	config_json = jsonencode({
-		Partition = "default"
-
 		TransparentProxy = {
 			MeshDestinationsOnly = true
 		}
@@ -260,6 +259,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the configuration entry being registered.
 
+* `partition` - (Optional, Enterprise Only) The partition the config entry is associated with.
+
 * `namespace` - (Optional, Enterprise Only) The namespace to create the config entry within.
 
 * `config_json` - (Optional) An arbitrary map of configuration values.
@@ -273,5 +274,9 @@ The following attributes are exported:
 * `kind` - The kind of the configuration entry.
 
 * `name` - The name of the configuration entry.
+
+* `partition` - The partition the config entry is associated with.
+
+* `namespace` - The namespace to create the config entry within.
 
 * `config_json` - A map of configuration values.


### PR DESCRIPTION
Having the partition argument in `config_json` was causing an issue as
the provider was not reading the result back from the correct partition.
This is now fixed by having `partition` as an actual argument of
`consul_config_entry`.

Also, fix some flaky tests by improving the tests in startTestServer().

Also, simplify local testing by adding an install target in the Makefile.