### PR TITLE
Add support for partitions management

### DIFF
--- a/consul/data_source_consul_acl_token_secret_id.go
+++ b/consul/data_source_consul_acl_token_secret_id.go
@@ -24,6 +24,11 @@ func dataSourceConsulACLTokenSecretID() *schema.Resource {
 				Optional: true,
 			},
 
+			"partition": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			// Out parameters
 			"secret_id": {
 				Type:      schema.TypeString,

--- a/consul/data_source_consul_acl_token_secret_id_test.go
+++ b/consul/data_source_consul_acl_token_secret_id_test.go
@@ -62,6 +62,41 @@ func TestAccDataACLTokenSecretID_namespaceEE(t *testing.T) {
 	})
 }
 
+func TestAccDataACLTokenSecretID_partitionCE(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		Providers: providers,
+		PreCheck:  func() { skipTestOnConsulEnterpriseEdition(t) },
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataACLTokenSecretIDConfigPartitionCE,
+				ExpectError: partitionEnterpriseFeature,
+			},
+		},
+	})
+}
+
+func TestAccDataACLTokenSecretID_partitionEE(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		Providers: providers,
+		PreCheck:  func() { skipTestOnConsulCommunityEdition(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataACLTokenSecretIDConfigNamespaceEE,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.consul_acl_token_secret_id.read", "pgp_key", ""),
+					resource.TestCheckResourceAttr("data.consul_acl_token_secret_id.read", "encrypted_secret_id", ""),
+					resource.TestCheckResourceAttr("data.consul_acl_token_secret_id.read", "partition", "test-data-token-secret"),
+					testAccCheckTokenExistsAndValidUUID("data.consul_acl_token_secret_id.read", "secret_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataACLTokenSecretID_PGP(t *testing.T) {
 	providers, _ := startTestServer(t)
 
@@ -161,5 +196,37 @@ resource "consul_acl_token" "test" {
 data "consul_acl_token_secret_id" "read" {
   accessor_id = consul_acl_token.test.id
   namespace   = consul_namespace.test.name
+}
+`
+
+const testAccDataACLTokenSecretIDConfigPartitionCE = `
+data "consul_acl_token" "read" {
+  accessor_id = "foo"
+  partition   = "test-data-token"
+}
+`
+
+const testAccDataACLTokenSecretIDConfigPartitionEE = `
+resource "consul_partition" "test" {
+  name = "test-data-token-secret"
+}
+
+resource "consul_acl_policy" "test" {
+  name        = "test-data-token-secret"
+  rules       = "node \"\" { policy = \"read\" }"
+  datacenters = [ "dc1" ]
+  partition   = consul_partition.test.name
+}
+
+resource "consul_acl_token" "test" {
+  description = "test"
+  policies    = [consul_acl_policy.test.name]
+  local       = true
+  partition   = consul_partition.test.name
+}
+
+data "consul_acl_token_secret_id" "read" {
+  accessor_id = consul_acl_token.test.id
+  partition   = consul_partition.test.name
 }
 `

--- a/consul/resource_consul_partition.go
+++ b/consul/resource_consul_partition.go
@@ -1,0 +1,97 @@
+package consul
+
+import (
+	"context"
+	"fmt"
+
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceConsulPartition() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceConsulNamespaceCreate,
+		Read:   resourceConsulNamespaceRead,
+		Update: resourceConsulNamespaceUpdate,
+		Delete: resourceConsulNamespaceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceConsulPartitionCreate(d *schema.ResourceData, meta interface{}) error {
+	client, _, wOpts := getClient(d, meta)
+
+	partition := getPartitionFromResourceData(d)
+	partition, _, err := client.Partitions().Create(context.Background(), partition, wOpts)
+	if err != nil {
+		return fmt.Errorf("failed to create namespace: %v", err)
+	}
+	d.SetId(partition.Name)
+	return resourceConsulPartitionRead(d, meta)
+}
+
+func resourceConsulPartitionRead(d *schema.ResourceData, meta interface{}) error {
+	client, qOpts, _ := getClient(d, meta)
+	name := d.Id()
+
+	partition, _, err := client.Partitions().Read(context.Background(), name, qOpts)
+	if partition == nil {
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to read partition '%s': %v", name, err)
+	}
+
+	sw := newStateWriter(d)
+	sw.set("name", partition.Name)
+	sw.set("description", partition.Description)
+
+	return sw.error()
+}
+
+func resourceConsulPartitionUpdate(d *schema.ResourceData, meta interface{}) error {
+	client, _, wOpts := getClient(d, meta)
+
+	partition := getPartitionFromResourceData(d)
+	partition, _, err := client.Partitions().Update(context.Background(), partition, wOpts)
+	if err != nil {
+		return fmt.Errorf("failed to update partition '%s': %v", partition.Name, err)
+	}
+
+	return resourceConsulPartitionRead(d, meta)
+}
+
+func resourceConsulPartitionDelete(d *schema.ResourceData, meta interface{}) error {
+	client, _, wOpts := getClient(d, meta)
+
+	_, err := client.Partitions().Delete(context.Background(), d.Id(), wOpts)
+	if err != nil {
+		return fmt.Errorf("failed to delete namespace '%s': %v", d.Id(), err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func getPartitionFromResourceData(d *schema.ResourceData) *consulapi.Partition {
+	return &consulapi.Partition{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	}
+}

--- a/consul/resource_consul_partition_test.go
+++ b/consul/resource_consul_partition_test.go
@@ -1,0 +1,68 @@
+package consul
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+var partitionEnterpriseFeature = regexp.MustCompile("(?i)Consul Enterprise feature")
+
+func TestAccConsulPartition_FailOnCommunityEdition(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { skipTestOnConsulEnterpriseEdition(t) },
+		Providers: providers,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccConsulPartition,
+				ExpectError: regexp.MustCompile("failed to create partition: Unexpected response code: 404"),
+			},
+		},
+	})
+}
+
+func TestAccConsulPartition(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { skipTestOnConsulCommunityEdition(t) },
+		Providers: providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConsulPartition,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_partition.test", "name", "test"),
+					resource.TestCheckResourceAttr("consul_partition.test", "description", "test partition"),
+				),
+			},
+			{
+				Config: testAccConsulPartition_Update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_partition.test", "name", "test"),
+					resource.TestCheckResourceAttr("consul_partition.test", "description", "updated description"),
+				),
+			},
+			{
+				ResourceName:      "consul_partition.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+const testAccConsulPartition = `
+resource "consul_partition" "test" {
+	name        = "test"
+	description = "test partition"
+}
+`
+
+const testAccConsulPartition_Update = `
+resource "consul_partition" "test" {
+  name        = "test"
+  description = "updated description"
+}`


### PR DESCRIPTION
Many aspects of the provider already supported partitions. However we seemed to be lacking support for creating and deleting partitions as well as lookup up token secret ids for tokens in non-default partitions.

This PR adds a new consul_partition resource and modifies the consul_acl_token_secret_id data source to support partitions.