### PR TITLE
Support partitioned tokens in ACL secret id data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.15.1 (Unreleased)
 
+IMPROVEMENTS:
+
+* The `consul_acl_token_secret` datasource now supports reading tokens in a Consul Admin Partition ([#315](https://github.com/hashicorp/terraform-provider-consul/pull/315)).
+
 BUG FIXES:
 
 * The support of Admin Partition has been fixed for `consul_config_entry`: a new `partition` argument is now present and should be used instead of setting `Partition` in `config_json`.

--- a/consul/data_source_consul_acl_token_secret_id.go
+++ b/consul/data_source_consul_acl_token_secret_id.go
@@ -24,6 +24,11 @@ func dataSourceConsulACLTokenSecretID() *schema.Resource {
 				Optional: true,
 			},
 
+			"partition": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			// Out parameters
 			"secret_id": {
 				Type:      schema.TypeString,

--- a/consul/data_source_consul_acl_token_secret_id_test.go
+++ b/consul/data_source_consul_acl_token_secret_id_test.go
@@ -62,6 +62,41 @@ func TestAccDataACLTokenSecretID_namespaceEE(t *testing.T) {
 	})
 }
 
+func TestAccDataACLTokenSecretID_partitionCE(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		Providers: providers,
+		PreCheck:  func() { skipTestOnConsulEnterpriseEdition(t) },
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataACLTokenSecretIDConfigPartitionCE,
+				ExpectError: regexp.MustCompile("(?i)Consul Enterprise feature"),
+			},
+		},
+	})
+}
+
+func TestAccDataACLTokenSecretID_partitionEE(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		Providers: providers,
+		PreCheck:  func() { skipTestOnConsulCommunityEdition(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataACLTokenSecretIDConfigPartitionEE,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.consul_acl_token_secret_id.read", "pgp_key", ""),
+					resource.TestCheckResourceAttr("data.consul_acl_token_secret_id.read", "encrypted_secret_id", ""),
+					resource.TestCheckResourceAttr("data.consul_acl_token_secret_id.read", "partition", "test-data-token-secret"),
+					testAccCheckTokenExistsAndValidUUID("data.consul_acl_token_secret_id.read", "secret_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataACLTokenSecretID_PGP(t *testing.T) {
 	providers, _ := startTestServer(t)
 
@@ -161,5 +196,37 @@ resource "consul_acl_token" "test" {
 data "consul_acl_token_secret_id" "read" {
   accessor_id = consul_acl_token.test.id
   namespace   = consul_namespace.test.name
+}
+`
+
+const testAccDataACLTokenSecretIDConfigPartitionCE = `
+data "consul_acl_token" "read" {
+  accessor_id = "foo"
+  partition   = "test-data-token"
+}
+`
+
+const testAccDataACLTokenSecretIDConfigPartitionEE = `
+resource "consul_admin_partition" "test" {
+  name = "test-data-token-secret"
+}
+
+resource "consul_acl_policy" "test" {
+  name        = "test-data-token-secret"
+  rules       = "node \"\" { policy = \"read\" }"
+  datacenters = [ "dc1" ]
+  partition   = consul_admin_partition.test.name
+}
+
+resource "consul_acl_token" "test" {
+  description = "test"
+  policies    = [consul_acl_policy.test.name]
+  local       = true
+  partition   = consul_admin_partition.test.name
+}
+
+data "consul_acl_token_secret_id" "read" {
+  accessor_id = consul_acl_token.test.id
+  partition   = consul_admin_partition.test.name
 }
 `

--- a/website/docs/d/acl_token_secret_id.html.markdown
+++ b/website/docs/d/acl_token_secret_id.html.markdown
@@ -52,6 +52,7 @@ The following arguments are supported:
 
 * `accessor_id` - (Required) The accessor ID of the ACL token.
 * `namespace` - (Optional, Enterprise Only) The namespace to lookup the token.
+* `partition` - (Optional, Enterprise Only) The partition to lookup the token.
 * `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a keybase
   username in the form `keybase:some_person_that_exists`. **If you do not set this
   argument, the token secret ID will be written as plain text in the Terraform


### PR DESCRIPTION
## Description

This PR adds support for partitions to the `consul_acl_token_secret_id` resource.

Tokens can now be created with the `consul_acl_token` resource in non-default partitions and then have their secret ids retrieved with the data source.
