### PR TITLE
add feature to attach policies to roles

### DIFF
--- a/consul/resource_consul_acl_role_policy_attachment.go
+++ b/consul/resource_consul_acl_role_policy_attachment.go
@@ -1,0 +1,139 @@
+package consul
+
+import (
+	"fmt"
+	"strings"
+
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceConsulACLRolePolicyAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceConsulACLRolePolicyAttachmentCreate,
+		Read:   resourceConsulACLRolePolicyAttachmentRead,
+		Delete: resourceConsulACLRolePolicyAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"role_id": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Description: "The name of the role.",
+			},
+			"policy_id": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+				Description: "The policy name.",
+			},
+		},
+	}
+}
+
+func resourceConsulACLRolePolicyAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	client, qOpts, wOpts := getClient(d, meta)
+
+	roleID := d.Get("role_id").(string)
+
+	aclRole, _, err := client.ACL().RoleRead(roleID, qOpts)
+	if err != nil {
+		return fmt.Errorf("role '%s' not found", roleID)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	for _, policy := range aclRole.Policies {
+		if policy.ID == policyID {
+			return fmt.Errorf("policy '%s' already attached to role", policyID)
+		}
+	}
+
+	aclRole.Policies = append(aclRole.Policies, &consulapi.ACLRolePolicyLink{
+		ID: policyID,
+	})
+
+	_, _, err = client.ACL().RoleUpdate(aclRole, wOpts)
+	if err != nil {
+		return fmt.Errorf("error updating ACL role '%q' to set new policy attachment: '%s'", roleID, err)
+	}
+
+	id := fmt.Sprintf("%s:%s", roleID, policyID)
+
+	d.SetId(id)
+
+	return resourceConsulACLRolePolicyAttachmentRead(d, meta)
+}
+
+func resourceConsulACLRolePolicyAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	client, qOpts, _ := getClient(d, meta)
+
+	id := d.Id()
+
+	roleID, policyID, err := parseTwoPartID(id, "role_id", "policy_id")
+	if err != nil {
+		return fmt.Errorf("invalid ACL role policy attachment id '%q'", id)
+	}
+
+	aclRole, _, err := client.ACL().RoleRead(roleID, qOpts)
+	if err != nil {
+		if strings.Contains(err.Error(), "ACL not found") {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("failed to read role '%s': %v", id, err)
+	}
+
+	policyFound := false
+	for _, policy := range aclRole.Policies {
+		if policy.ID == policyID {
+			policyFound = true
+			break
+		}
+	}
+	if !policyFound {
+		d.SetId("")
+		return nil
+	}
+
+	if err = d.Set("role_id", roleID); err != nil {
+		return fmt.Errorf("error while setting 'role': %s", err)
+	}
+	if err = d.Set("policy_id", policyID); err != nil {
+		return fmt.Errorf("error while setting 'policy': %s", err)
+	}
+
+	return nil
+}
+
+func resourceConsulACLRolePolicyAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	client, qOpts, wOpts := getClient(d, meta)
+
+	id := d.Id()
+
+	roleID, policyID, err := parseTwoPartID(id, "role_id", "policy_id")
+	if err != nil {
+		return fmt.Errorf("invalid ACL role policy attachment id '%q'", id)
+	}
+
+	aclRole, _, err := client.ACL().RoleRead(roleID, qOpts)
+	if err != nil {
+		return fmt.Errorf("role '%s' not found", roleID)
+	}
+
+	for i, policy := range aclRole.Policies {
+		if policy.ID == policyID {
+			aclRole.Policies = append(aclRole.Policies[:i], aclRole.Policies[i+1:]...)
+			break
+		}
+	}
+
+	_, _, err = client.ACL().RoleUpdate(aclRole, wOpts)
+	if err != nil {
+		return fmt.Errorf("error updating ACL role '%q' to set new policy attachment: '%s'", roleID, err)
+	}
+
+	return nil
+}

--- a/consul/resource_consul_acl_role_policy_attachment_test.go
+++ b/consul/resource_consul_acl_role_policy_attachment_test.go
@@ -1,0 +1,203 @@
+package consul
+
+import (
+	"fmt"
+	"testing"
+
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func testAccCheckConsulACLRolePolicyAttachmentDestroy(client *consulapi.Client) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "consul_acl_role_policy_attachment" {
+				continue
+			}
+			roleID, policyID, err := parseTwoPartID(rs.Primary.ID, "role_id", "policy_id")
+			if err != nil {
+				return fmt.Errorf("Invalid ACL role attachment id! '%q'", rs.Primary.ID)
+			}
+			aclRole, _, _ := client.ACL().RoleRead(roleID, nil)
+			if aclRole != nil {
+				for _, policy := range aclRole.Policies {
+					if policy.ID == policyID {
+						return fmt.Errorf("ACL role policy attachment %q still exists", rs.Primary.ID)
+					}
+				}
+			}
+		}
+		return nil
+	}
+}
+
+func testAccCheckRolePolicyName(client *consulapi.Client) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources["consul_acl_role_policy_attachment.test"]
+		if !ok {
+			return fmt.Errorf("Not Found: consul_acl_role_policy_attachment.test")
+		}
+
+		roleIDFromState, policyIDFromState, err := parseTwoPartID(rs.Primary.ID, "role", "policy")
+		if err != nil {
+			return err
+		}
+
+		_, _, err = client.ACL().RoleRead(roleIDFromState, nil)
+		if err != nil {
+			return fmt.Errorf("Unable to retrieve role %q", roleIDFromState)
+		}
+
+		rs, ok = s.RootModule().Resources["consul_acl_role_policy_attachment.test"]
+		if !ok {
+			return fmt.Errorf("Not Found: consul_acl_role_policy_attachment.test")
+		}
+
+		roleIDFromResource := rs.Primary.Attributes["role_id"]
+		if roleIDFromResource == "" {
+			return fmt.Errorf("No role is set in attachment")
+		}
+
+		if roleIDFromResource != roleIDFromState {
+			return fmt.Errorf("%s != %s", roleIDFromResource, roleIDFromState)
+		}
+
+		policyIDFromResource := rs.Primary.Attributes["policy_id"]
+		if policyIDFromResource == "" {
+			return fmt.Errorf("No policy is set in attachment")
+		}
+
+		if policyIDFromResource != policyIDFromState {
+			return fmt.Errorf("%s != %s", policyIDFromState, policyIDFromResource)
+		}
+
+		return nil
+	}
+}
+
+func TestAccConsulACLRolePolicyAttachment_basic(t *testing.T) {
+	providers, client := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    providers,
+		CheckDestroy: testAccCheckConsulACLRolePolicyAttachmentDestroy(client),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLRolePolicyAttachmentConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRolePolicyName(client),
+				),
+			},
+			{
+				Config: testResourceACLRolePolicyAttachmentConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRolePolicyName(client),
+				),
+			},
+			{
+				Config: testResourceACLRolePolicyAttachmentConfigUpdate,
+			},
+		},
+	})
+}
+
+func TestAccConsulACLRolePolicyAttachment_import(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("bad state: %s", s)
+		}
+		_, ok := s[0].Attributes["role_id"]
+		if !ok {
+			return fmt.Errorf("bad role: %s", s)
+		}
+		_, ok = s[0].Attributes["policy_id"]
+		if !ok {
+			return fmt.Errorf("bad policy: %s", s)
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers: providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLRolePolicyAttachmentConfigBasic,
+			},
+			{
+				ResourceName:     "consul_acl_role_policy_attachment.test",
+				ImportState:      true,
+				ImportStateCheck: checkFn,
+			},
+		},
+	})
+}
+
+const testResourceACLRolePolicyAttachmentConfigBasic = `
+resource "consul_acl_policy" "default" {
+	name = "default"
+	rules = "service \"\" { policy = \"read\" }"
+	datacenters = [ "dc1" ]
+}
+
+resource "consul_acl_role" "test" {
+	name = "test"
+
+	service_identities {
+        service_name = "foo"
+    }
+
+	policies = ["${consul_acl_policy.default.id}"]
+
+	lifecycle {
+		ignore_changes = ["policies"]
+	}	
+}
+
+resource "consul_acl_policy" "test" {
+	name = "test"
+	rules = "node \"\" { policy = \"read\" }"
+	datacenters = [ "dc1" ]
+}
+
+resource "consul_acl_role_policy_attachment" "test" {
+    role_id   = "${consul_acl_role.test.id}"
+    policy_id = "${consul_acl_policy.test.id}"
+}
+`
+
+const testResourceACLRolePolicyAttachmentConfigUpdate = `
+resource "consul_acl_policy" "default" {
+	name = "default"
+	rules = "service \"\" { policy = \"read\" }"
+	datacenters = [ "dc1" ]
+}
+
+resource "consul_acl_role" "test" {
+	name = "test"
+
+	service_identities {
+        service_name = "foo"
+    }
+
+	policies = ["${consul_acl_policy.default.id}"]
+
+	lifecycle {
+		ignore_changes = ["policies"]
+	}	
+}
+
+resource "consul_acl_policy" "test2" {
+	name = "test2"
+	rules = "node \"\" { policy = \"write\" }"
+	datacenters = [ "dc1" ]
+}
+
+resource "consul_acl_role_policy_attachment" "test" {
+    role_id   = "${consul_acl_role.test.id}"
+    policy_id = "${consul_acl_policy.test2.id}"
+}
+`

--- a/consul/resource_provider.go
+++ b/consul/resource_provider.go
@@ -181,6 +181,7 @@ func Provider() terraform.ResourceProvider {
 			"consul_acl_token":                   resourceConsulACLToken(),
 			"consul_acl_token_policy_attachment": resourceConsulACLTokenPolicyAttachment(),
 			"consul_acl_token_role_attachment":   resourceConsulACLTokenRoleAttachment(),
+			"consul_acl_role_policy_attachment":  resourceConsulACLRolePolicyAttachment(),
 			"consul_admin_partition":             resourceConsulAdminPartition(),
 			"consul_agent_service":               resourceConsulAgentService(),
 			"consul_catalog_entry":               resourceConsulCatalogEntry(),


### PR DESCRIPTION
this is a resource for attaching policies to role existing outside of the scope of terraform in the same fashion as `consul_acl_token_policy_attachment` or `consul_acl_token_role_attachment ` 