### PR TITLE
Add docs, examples and tests for jwt-provider config entry and jwt referencing intentions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,8 +24,8 @@ jobs:
       run: make test
     - name: Run OSS acceptance tests
       run: |
-        curl -LO https://releases.hashicorp.com/consul/1.15.2/consul_1.15.2_linux_amd64.zip
-        sudo unzip consul_1.15.2_linux_amd64.zip consul -d /usr/local/bin
+        curl -LO https://releases.hashicorp.com/consul/1.16.0/consul_1.16.0_linux_amd64.zip
+        sudo unzip consul_1.16.0_linux_amd64.zip consul -d /usr/local/bin
         SKIP_REMOTE_DATACENTER_TESTS=1 make testacc TESTARGS="-count=1"
     - name: Run go vet
       run: make vet

--- a/consul/resource_consul_config_entry_ce_test.go
+++ b/consul/resource_consul_config_entry_ce_test.go
@@ -78,21 +78,24 @@ func TestAccConsulConfigEntryCE_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConsulConfigEntryCE_ServiceConfigL4,
+				Config:             testAccConsulConfigEntryCE_ServiceConfigL4,
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "name", "api-service"),
 					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "kind", "service-intentions"),
 				),
 			},
 			{
-				Config: testAccConsulConfigEntryCE_ServiceConfigL7,
+				Config:             testAccConsulConfigEntryCE_ServiceConfigL7,
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "name", "fort-knox"),
 					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "kind", "service-intentions"),
 				),
 			},
 			{
-				Config: testAccConsulConfigEntryCE_ServiceConfigL7b,
+				Config:             testAccConsulConfigEntryCE_ServiceConfigL7b,
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "name", "api"),
 					resource.TestCheckResourceAttr("consul_config_entry.service_intentions", "kind", "service-intentions"),
@@ -166,6 +169,48 @@ func TestAccConsulConfigEntryCE_Mesh(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("consul_config_entry.mesh", "name", "mesh"),
 					resource.TestCheckResourceAttr("consul_config_entry.mesh", "kind", "mesh"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConsulConfigEntryCE_JWTProvider_Remote(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { skipTestOnConsulEnterpriseEdition(t) },
+		Providers: providers,
+		Steps: []resource.TestStep{
+			{
+				Config:             TestAccConsulConfigEntryCE_jwtRemote,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.jwt_provider", "id", "jwt-provider-okta"),
+					resource.TestCheckResourceAttr("consul_config_entry.jwt_provider", "name", "okta"),
+					resource.TestCheckResourceAttr("consul_config_entry.jwt_provider", "kind", "jwt-provider"),
+					resource.TestCheckResourceAttr("consul_config_entry.jwt_provider", "config_json", "{\"ClockSkewSeconds\":30,\"Forwarding\":{\"HeaderName\":\"test-token\"},\"Issuer\":\"test-issuer\",\"JSONWebKeySet\":{\"Remote\":{\"FetchAsynchronously\":true,\"URI\":\"https://127.0.0.1:9091\"}}}"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConsulConfigEntryCE_JWTProvider_Local(t *testing.T) {
+	providers, _ := startTestServer(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { skipTestOnConsulEnterpriseEdition(t) },
+		Providers: providers,
+		Steps: []resource.TestStep{
+			{
+				ExpectNonEmptyPlan: true,
+				Config:             TestAccConsulConfigEntryCE_jwtLocal,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("consul_config_entry.jwt_provider", "id", "jwt-provider-auth0"),
+					resource.TestCheckResourceAttr("consul_config_entry.jwt_provider", "name", "auth0"),
+					resource.TestCheckResourceAttr("consul_config_entry.jwt_provider", "kind", "jwt-provider"),
+					resource.TestCheckResourceAttr("consul_config_entry.jwt_provider", "config_json", "{\"ClockSkewSeconds\":30,\"Issuer\":\"auth0-issuer\",\"JSONWebKeySet\":{\"Local\":{\"JWKS\":\"eyJrZXlzIjogW3sKICAiY3J2IjogIlAtMjU2IiwKICAia2V5X29wcyI6IFsKICAgICJ2ZXJpZnkiCiAgXSwKICAia3R5IjogIkVDIiwKICAieCI6ICJXYzl1WnVQYUI3S2gyRk1jOXd0SmpSZThYRDR5VDJBWU5BQWtyWWJWanV3IiwKICAieSI6ICI2OGhSVEppSk5Pd3RyaDRFb1BYZVZuUnVIN2hpU0RKX2xtYmJqZkRmV3EwIiwKICAiYWxnIjogIkVTMjU2IiwKICAidXNlIjogInNpZyIsCiAgImtpZCI6ICJhYzFlOGY5MGVkZGY2MWM0MjljNjFjYTA1YjRmMmUwNyIKfV19\"}}}"),
 				),
 			},
 		},
@@ -395,11 +440,31 @@ resource "consul_config_entry" "terminating_gateway" {
 `
 
 const testAccConsulConfigEntryCE_ServiceConfigL4 = `
+resource "consul_config_entry" "jwt_provider" {
+	name = "okta"
+	kind = "jwt-provider"
+
+	config_json = jsonencode({
+		Issuer = "test-issuer"
+		JSONWebKeySet = {
+			Remote = {
+				URI = "https://127.0.0.1:9091"
+				FetchAsynchronously = true
+			}
+		}
+	})
+}
+
 resource "consul_config_entry" "service_intentions" {
 	name = "api-service"
 	kind = "service-intentions"
 
 	config_json = jsonencode({
+		JWT = {
+			Providers = [
+				{ name = consul_config_entry.jwt_provider.name }
+			]
+		}
 		Sources = [
 			{
 				Action     = "allow"
@@ -431,6 +496,21 @@ resource "consul_config_entry" "sd" {
 	})
 }
 
+resource "consul_config_entry" "jwt_provider" {
+	name = "okta"
+	kind = "jwt-provider"
+
+	config_json = jsonencode({
+		Issuer = "test-issuer"
+		JSONWebKeySet = {
+			Remote = {
+				URI = "https://127.0.0.1:9091"
+				FetchAsynchronously = true
+			}
+		}
+	})
+}
+
 resource "consul_config_entry" "service_intentions" {
 	name = consul_config_entry.sd.name
 	kind = "service-intentions"
@@ -445,6 +525,11 @@ resource "consul_config_entry" "service_intentions" {
 						HTTP   = {
 							Methods   = ["GET", "HEAD"]
 							PathExact = "/healtz"
+						}
+						JWT = {
+							Providers = [
+								{ name = consul_config_entry.jwt_provider.name }
+							]
 						}
 					}
 				]
@@ -488,6 +573,21 @@ resource "consul_config_entry" "sd" {
 	})
 }
 
+resource "consul_config_entry" "jwt_provider" {
+	name = "okta"
+	kind = "jwt-provider"
+
+	config_json = jsonencode({
+		Issuer = "test-issuer"
+		JSONWebKeySet = {
+			Remote = {
+				URI = "https://127.0.0.1:9091"
+				FetchAsynchronously = true
+			}
+		}
+	})
+}
+
 resource "consul_config_entry" "service_intentions" {
 	name = consul_config_entry.sd.name
 	kind = "service-intentions"
@@ -502,6 +602,11 @@ resource "consul_config_entry" "service_intentions" {
 						HTTP = {
 							Methods    = ["GET", "PUT", "POST", "DELETE", "HEAD"]
 							PathPrefix = "/v2"
+						}
+						JWT = {
+							Providers = [
+								{ name = consul_config_entry.jwt_provider.name }
+							]
 						}
 					}
 				],
@@ -697,6 +802,41 @@ resource "consul_config_entry" "mesh" {
 
 		TransparentProxy = {
 			MeshDestinationsOnly = true
+		}
+	})
+}
+`
+const TestAccConsulConfigEntryCE_jwtRemote = `
+resource "consul_config_entry" "jwt_provider" {
+	name = "okta"
+	kind = "jwt-provider"
+
+	config_json = jsonencode({
+		Issuer = "test-issuer"
+		JSONWebKeySet = {
+			Remote = {
+				URI = "https://127.0.0.1:9091"
+				FetchAsynchronously = true
+			}
+		}
+		Forwarding = {
+			HeaderName = "test-token"
+		}
+	})
+}
+`
+
+const TestAccConsulConfigEntryCE_jwtLocal = `
+resource "consul_config_entry" "jwt_provider" {
+	name = "auth0"
+	kind = "jwt-provider"
+
+	config_json = jsonencode({
+		Issuer = "auth0-issuer"
+		JSONWebKeySet = {
+			Local = {
+        JWKS = "eyJrZXlzIjogW3sKICAiY3J2IjogIlAtMjU2IiwKICAia2V5X29wcyI6IFsKICAgICJ2ZXJpZnkiCiAgXSwKICAia3R5IjogIkVDIiwKICAieCI6ICJXYzl1WnVQYUI3S2gyRk1jOXd0SmpSZThYRDR5VDJBWU5BQWtyWWJWanV3IiwKICAieSI6ICI2OGhSVEppSk5Pd3RyaDRFb1BYZVZuUnVIN2hpU0RKX2xtYmJqZkRmV3EwIiwKICAiYWxnIjogIkVTMjU2IiwKICAidXNlIjogInNpZyIsCiAgImtpZCI6ICJhYzFlOGY5MGVkZGY2MWM0MjljNjFjYTA1YjRmMmUwNyIKfV19"
+    	}
 		}
 	})
 }

--- a/docs/resources/config_entry.md
+++ b/docs/resources/config_entry.md
@@ -171,6 +171,24 @@ resource "consul_config_entry" "sd" {
   })
 }
 
+resource "consul_config_entry" "jwt_provider" {
+	name = "test-provider"
+	kind = "jwt-provider"
+
+	config_json = jsonencode({
+		Issuer = "test-issuer"
+		JSONWebKeySet = {
+			Remote = {
+				URI = "https://127.0.0.1:9091"
+				FetchAsynchronously = true
+			}
+		}
+		Forwarding = {
+			HeaderName = "test-token"
+		}
+	})
+}
+
 resource "consul_config_entry" "service_intentions" {
   name = consul_config_entry.sd.name
   kind = "service-intentions"
@@ -185,6 +203,13 @@ resource "consul_config_entry" "service_intentions" {
             HTTP   = {
               Methods   = ["GET", "HEAD"]
               PathExact = "/healtz"
+            }
+            JWT = {
+              Providers = [
+                {
+                  Name = consul_config_entry.jwt_provider.name
+                }
+              ]
             }
           }
         ]
@@ -247,6 +272,29 @@ resource "consul_config_entry" "mesh" {
 			MeshDestinationsOnly = true
 		}
 	})
+}
+```
+
+### `jwt-provider` config entry
+
+```hcl
+resource "consul_config_entry" "jwt_provider" {
+  name = "provider-name"
+  kind = "jwt-provider"
+  
+  config_json = jsonencode({
+    Issuer = "https://your.issuer.com"
+    JSONWebKeySet = {
+      Remote = {
+        URI = "https://your-remote.jwks.com"
+        FetchAsynchronously = true
+        CacheDuration = "10s"
+      }
+    }
+    Forwarding = {
+      HeaderName = "test-token"
+    }
+  })
 }
 ```
 


### PR DESCRIPTION
This PR: 

- [x] Bumps CI consul version to match the API version introduced in (https://github.com/hashicorp/terraform-provider-consul/pull/346) 
- [x] Add tests for the new JWT config entry (one remote and one local)
- [x] adds some example of intentions referencing JWT 
- [x] Adds some docs example for JWT auth