### PR TITLE
Don't panic on missing role in consul_acl_role_policy_attachment

### DIFF
--- a/consul/data_source_consul_acl_policy.go
+++ b/consul/data_source_consul_acl_policy.go
@@ -6,7 +6,6 @@ package consul
 import (
 	"fmt"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -53,24 +52,12 @@ func dataSourceConsulACLPolicyRead(d *schema.ResourceData, meta interface{}) err
 	client, qOpts, _ := getClient(d, meta)
 	name := d.Get("name").(string)
 
-	var policyEntry *consulapi.ACLPolicyListEntry
-	policyEntries, _, err := client.ACL().PolicyList(qOpts)
-	if err != nil {
-		return fmt.Errorf("could not list policies: %v", err)
-	}
-	for _, pe := range policyEntries {
-		if pe.Name == name {
-			policyEntry = pe
-			break
-		}
-	}
-	if policyEntry == nil {
-		return fmt.Errorf("could not find policy '%s'", name)
-	}
-
-	policy, _, err := client.ACL().PolicyRead(policyEntry.ID, qOpts)
+	policy, _, err := client.ACL().PolicyReadByName(name, qOpts)
 	if err != nil {
 		return fmt.Errorf("could not read policy '%s': %v", name, err)
+	}
+	if policy == nil {
+		return fmt.Errorf("could not find policy %q", name)
 	}
 
 	d.SetId(policy.ID)

--- a/consul/data_source_consul_acl_policy_test.go
+++ b/consul/data_source_consul_acl_policy_test.go
@@ -18,7 +18,7 @@ func TestAccDataACLPolicy_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceACLPolicyConfigNotFound,
-				ExpectError: regexp.MustCompile("could not find policy 'not-found'"),
+				ExpectError: regexp.MustCompile(`could not find policy "not-found"`),
 			},
 			{
 				Config: testAccDataSourceACLPolicyConfigBasic,

--- a/consul/resource_consul_acl_auth_method_test.go
+++ b/consul/resource_consul_acl_auth_method_test.go
@@ -135,7 +135,6 @@ func testAuthMethodCACert(client *consulapi.Client, name, v string) func(s *terr
 		if err != nil {
 			return err
 		}
-
 		if authMethod == nil {
 			return fmt.Errorf("Auth method %q does not exists", name)
 		}


### PR DESCRIPTION
`resourceConsulACLRolePolicyAttachmentCreate()` and `resourceConsulACLRolePolicyAttachmentDelete()`
were not checking properly if the given role ID was not found in Consul.

Some functions in the Consul SDK return an error when the object is missing,
other return a `nil` object.

In the case of `RoleRead()` I was checking for the wrong thing. I checked the
rest of the ACL resources and as far as I know it, this was the only
resource impacted.

I also update the `consul_acl_policy` data source to use the new
`PolicyReadByName()` function.

Closes https://github.com/hashicorp/terraform-provider-consul/issues/378