### PR TITLE
Wait until ACL resources are replicated to the local DC 

### DIFF
--- a/consul/replication.go
+++ b/consul/replication.go
@@ -1,0 +1,61 @@
+package consul
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+)
+
+func waitForACLTokenReplication(acl *api.ACL, qOpts *api.QueryOptions, index uint64) error {
+	for attempt := 0; attempt <= 12; attempt++ {
+		rs, _, err := acl.Replication(qOpts)
+		if err != nil {
+			return fmt.Errorf("error fetching ACL replication status: %w", err)
+		}
+
+		if !rs.Enabled || rs.ReplicatedTokenIndex >= index {
+			return nil
+		}
+
+		time.Sleep(time.Duration(math.Pow(2, float64(attempt))) * time.Millisecond)
+	}
+
+	return errors.New("timed out waiting for ACL replication")
+}
+
+func waitForACLPolicyReplication(acl *api.ACL, qOpts *api.QueryOptions, index uint64) error {
+	for attempt := 0; attempt <= 12; attempt++ {
+		rs, _, err := acl.Replication(qOpts)
+		if err != nil {
+			return fmt.Errorf("error fetching ACL replication status: %w", err)
+		}
+
+		if !rs.Enabled || rs.ReplicatedIndex >= index {
+			return nil
+		}
+
+		time.Sleep(time.Duration(math.Pow(2, float64(attempt))) * time.Millisecond)
+	}
+
+	return errors.New("timed out waiting for ACL replication")
+}
+
+func waitForACLRoleReplication(acl *api.ACL, qOpts *api.QueryOptions, index uint64) error {
+	for attempt := 0; attempt <= 12; attempt++ {
+		rs, _, err := acl.Replication(qOpts)
+		if err != nil {
+			return fmt.Errorf("error fetching ACL replication status: %w", err)
+		}
+
+		if !rs.Enabled || rs.ReplicatedRoleIndex >= index {
+			return nil
+		}
+
+		time.Sleep(time.Duration(math.Pow(2, float64(attempt))) * time.Millisecond)
+	}
+
+	return errors.New("timed out waiting for ACL replication")
+}

--- a/consul/replication.go
+++ b/consul/replication.go
@@ -16,7 +16,7 @@ func waitForACLTokenReplication(acl *api.ACL, qOpts *api.QueryOptions, index uin
 			return fmt.Errorf("error fetching ACL replication status: %w", err)
 		}
 
-		if !rs.Enabled || rs.ReplicatedTokenIndex >= index {
+		if !rs.Enabled || rs.ReplicationType != "tokens" || rs.ReplicatedTokenIndex >= index {
 			return nil
 		}
 

--- a/consul/resource_consul_acl_role.go
+++ b/consul/resource_consul_acl_role.go
@@ -149,6 +149,10 @@ func resourceConsulACLRoleCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("failed to create role '%s': %s", name, err)
 	}
 
+	if err := waitForACLRoleReplication(client.ACL(), qOpts, role.CreateIndex); err != nil {
+		return err
+	}
+
 	d.SetId(role.ID)
 	return resourceConsulACLRoleRead(d, meta)
 }
@@ -236,6 +240,10 @@ func resourceConsulACLRoleUpdate(d *schema.ResourceData, meta interface{}) error
 	role, _, err = ACL.RoleUpdate(role, wOpts)
 	if err != nil {
 		return fmt.Errorf("failed to update role '%s': %s", d.Id(), err)
+	}
+
+	if err := waitForACLRoleReplication(client.ACL(), qOpts, role.ModifyIndex); err != nil {
+		return err
 	}
 
 	d.SetId(role.ID)

--- a/consul/resource_consul_acl_role_policy_attachment.go
+++ b/consul/resource_consul_acl_role_policy_attachment.go
@@ -62,9 +62,13 @@ func resourceConsulACLRolePolicyAttachmentCreate(d *schema.ResourceData, meta in
 		Name: newPolicyName,
 	})
 
-	_, _, err = client.ACL().RoleUpdate(role, wOpts)
+	u, _, err := client.ACL().RoleUpdate(role, wOpts)
 	if err != nil {
 		return fmt.Errorf("error updating role '%q' to set new policy attachment: '%s'", roleID, err)
+	}
+
+	if err := waitForACLRoleReplication(client.ACL(), qOpts, u.ModifyIndex); err != nil {
+		return err
 	}
 
 	id := fmt.Sprintf("%s:%s", roleID, newPolicyName)

--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -163,7 +163,7 @@ func resourceConsulACLToken() *schema.Resource {
 }
 
 func resourceConsulACLTokenCreate(d *schema.ResourceData, meta interface{}) error {
-	client, _, wOpts := getClient(d, meta)
+	client, qOpts, wOpts := getClient(d, meta)
 
 	log.Printf("[DEBUG] Creating ACL token")
 
@@ -175,6 +175,10 @@ func resourceConsulACLTokenCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Created ACL token %q", token.AccessorID)
+
+	if err := waitForACLTokenReplication(client.ACL(), qOpts, token.CreateIndex); err != nil {
+		return err
+	}
 
 	d.SetId(token.AccessorID)
 
@@ -265,7 +269,7 @@ func getTemplateVariables(templatedPolicy *consulapi.ACLTemplatedPolicy) []map[s
 }
 
 func resourceConsulACLTokenUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, _, wOpts := getClient(d, meta)
+	client, qOpts, wOpts := getClient(d, meta)
 
 	id := d.Id()
 	log.Printf("[DEBUG] Updating ACL token %q", id)
@@ -273,11 +277,15 @@ func resourceConsulACLTokenUpdate(d *schema.ResourceData, meta interface{}) erro
 	aclToken := getToken(d)
 	aclToken.AccessorID = id
 
-	_, _, err := client.ACL().TokenUpdate(aclToken, wOpts)
+	u, _, err := client.ACL().TokenUpdate(aclToken, wOpts)
 	if err != nil {
 		return fmt.Errorf("error updating ACL token %q: %s", id, err)
 	}
 	log.Printf("[DEBUG] Updated ACL token %q", id)
+
+	if err := waitForACLTokenReplication(client.ACL(), qOpts, u.ModifyIndex); err != nil {
+		return err
+	}
 
 	return resourceConsulACLTokenRead(d, meta)
 }

--- a/consul/resource_consul_acl_token.go
+++ b/consul/resource_consul_acl_token.go
@@ -176,8 +176,10 @@ func resourceConsulACLTokenCreate(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Created ACL token %q", token.AccessorID)
 
-	if err := waitForACLTokenReplication(client.ACL(), qOpts, token.CreateIndex); err != nil {
-		return err
+	if !aclToken.Local {
+		if err := waitForACLTokenReplication(client.ACL(), qOpts, token.CreateIndex); err != nil {
+			return err
+		}
 	}
 
 	d.SetId(token.AccessorID)
@@ -283,8 +285,10 @@ func resourceConsulACLTokenUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 	log.Printf("[DEBUG] Updated ACL token %q", id)
 
-	if err := waitForACLTokenReplication(client.ACL(), qOpts, u.ModifyIndex); err != nil {
-		return err
+	if !aclToken.Local {
+		if err := waitForACLTokenReplication(client.ACL(), qOpts, u.ModifyIndex); err != nil {
+			return err
+		}
 	}
 
 	return resourceConsulACLTokenRead(d, meta)

--- a/consul/resource_consul_acl_token_policy_attachment.go
+++ b/consul/resource_consul_acl_token_policy_attachment.go
@@ -58,9 +58,13 @@ func resourceConsulACLTokenPolicyAttachmentCreate(d *schema.ResourceData, meta i
 		Name: newPolicyName,
 	})
 
-	_, _, err = client.ACL().TokenUpdate(aclToken, wOpts)
+	u, _, err := client.ACL().TokenUpdate(aclToken, wOpts)
 	if err != nil {
 		return fmt.Errorf("error updating ACL token '%q' to set new policy attachment: '%s'", tokenID, err)
+	}
+
+	if err := waitForACLTokenReplication(client.ACL(), qOpts, u.ModifyIndex); err != nil {
+		return err
 	}
 
 	id := fmt.Sprintf("%s:%s", tokenID, newPolicyName)

--- a/consul/resource_consul_acl_token_policy_attachment.go
+++ b/consul/resource_consul_acl_token_policy_attachment.go
@@ -63,8 +63,10 @@ func resourceConsulACLTokenPolicyAttachmentCreate(d *schema.ResourceData, meta i
 		return fmt.Errorf("error updating ACL token '%q' to set new policy attachment: '%s'", tokenID, err)
 	}
 
-	if err := waitForACLTokenReplication(client.ACL(), qOpts, u.ModifyIndex); err != nil {
-		return err
+	if !aclToken.Local {
+		if err := waitForACLTokenReplication(client.ACL(), qOpts, u.ModifyIndex); err != nil {
+			return err
+		}
 	}
 
 	id := fmt.Sprintf("%s:%s", tokenID, newPolicyName)

--- a/consul/resource_consul_acl_token_role_attachment.go
+++ b/consul/resource_consul_acl_token_role_attachment.go
@@ -63,8 +63,10 @@ func resourceConsulACLTokenRoleAttachmentCreate(d *schema.ResourceData, meta int
 		return fmt.Errorf("error updating ACL token '%q' to set new role attachment: '%s'", tokenID, err)
 	}
 
-	if err := waitForACLTokenReplication(client.ACL(), qOpts, u.CreateIndex); err != nil {
-		return err
+	if !aclToken.Local {
+		if err := waitForACLTokenReplication(client.ACL(), qOpts, u.CreateIndex); err != nil {
+			return err
+		}
 	}
 
 	id := fmt.Sprintf("%s:%s", tokenID, roleName)

--- a/consul/resource_consul_acl_token_role_attachment.go
+++ b/consul/resource_consul_acl_token_role_attachment.go
@@ -58,9 +58,13 @@ func resourceConsulACLTokenRoleAttachmentCreate(d *schema.ResourceData, meta int
 		Name: roleName,
 	})
 
-	_, _, err = client.ACL().TokenUpdate(aclToken, wOpts)
+	u, _, err := client.ACL().TokenUpdate(aclToken, wOpts)
 	if err != nil {
 		return fmt.Errorf("error updating ACL token '%q' to set new role attachment: '%s'", tokenID, err)
+	}
+
+	if err := waitForACLTokenReplication(client.ACL(), qOpts, u.CreateIndex); err != nil {
+		return err
 	}
 
 	id := fmt.Sprintf("%s:%s", tokenID, roleName)


### PR DESCRIPTION
fixes #249

During creation/updates of ACL resources (policies, roles, tokens...) wait until the resource is replicated to the local DC to consider the operation successful.

This is to prevent the error "Root resource was present, but now absent." where Terraform tries to fetch the newly created resource before it is replicated to the local DC.