### PR TITLE
consul_config_entry_service_intentions: Fix NPE when optional JWT unset

### DIFF
--- a/consul/resource_consul_config_entry_service_intentions.go
+++ b/consul/resource_consul_config_entry_service_intentions.go
@@ -434,30 +434,32 @@ func (s *serviceIntentions) Write(ce consulapi.ConfigEntry, d *schema.ResourceDa
 	}
 	sw.set("meta", meta)
 
-	jwt := make([]map[string]interface{}, 1)
-	jwt[0] = make(map[string]interface{})
-	jwt[0]["providers"] = make([]map[string]interface{}, 0)
-	jwtProviders := make([]map[string]interface{}, 0)
-	for _, jwtProvider := range si.JWT.Providers {
-		jwtProviderMap := make(map[string]interface{})
-		jwtProviderMap["name"] = jwtProvider.Name
-		verifyClaims := make([]map[string]interface{}, 0)
-		for _, vc := range jwtProvider.VerifyClaims {
-			vcMap := make(map[string]interface{})
-			vcPaths := make([]string, 0)
-			for _, p := range vc.Path {
-				vcPaths = append(vcPaths, p)
+	if si.JWT != nil {
+		jwt := make([]map[string]interface{}, 1)
+		jwt[0] = make(map[string]interface{})
+		jwt[0]["providers"] = make([]map[string]interface{}, 0)
+		jwtProviders := make([]map[string]interface{}, 0)
+		for _, jwtProvider := range si.JWT.Providers {
+			jwtProviderMap := make(map[string]interface{})
+			jwtProviderMap["name"] = jwtProvider.Name
+			verifyClaims := make([]map[string]interface{}, 0)
+			for _, vc := range jwtProvider.VerifyClaims {
+				vcMap := make(map[string]interface{})
+				vcPaths := make([]string, 0)
+				for _, p := range vc.Path {
+					vcPaths = append(vcPaths, p)
+				}
+				vcMap["path"] = vcPaths
+				vcMap["value"] = vc.Value
+				verifyClaims = append(verifyClaims, vcMap)
 			}
-			vcMap["path"] = vcPaths
-			vcMap["value"] = vc.Value
-			verifyClaims = append(verifyClaims, vcMap)
+			jwtProviderMap["verify_claims"] = verifyClaims
+			jwtProviders = append(jwtProviders, jwtProviderMap)
 		}
-		jwtProviderMap["verify_claims"] = verifyClaims
-		jwtProviders = append(jwtProviders, jwtProviderMap)
-	}
-	jwt[0]["providers"] = jwtProviders
+		jwt[0]["providers"] = jwtProviders
 
-	sw.set("jwt", jwt)
+		sw.set("jwt", jwt)
+	}
 
 	sources := make([]map[string]interface{}, 0)
 	for _, source := range si.Sources {


### PR DESCRIPTION
`jwt` is an optional parameter on the service intention config. When it was not set, the plugin would segfault due to a null pointer dereference on the ServiceIntentionsConfigEntry.JWT.

This adds a check for `si.JWT != nil` and skips building the `jwt` payload when it is not set.

Stack trace observed:
```
Stack trace from the terraform-provider-consul plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xf0eb82]

goroutine 49 [running]:
github.com/hashicorp/terraform-provider-consul/consul.(*serviceIntentions).Write(0xc000b97598?, {0x14eb950?, 0xc000813100?}, 0xc00078c150?, 0x12?)
        /tmp/guix-build-terraform-provider-consul-2.20.0.drv-0/source/source/consul/resource_consul_config_entry_service_intentions.go:441 +0x3a2
github.com/hashicorp/terraform-provider-consul/consul.configEntryImplementationRead.func1(0xc0007a0fc0, {0x102a6a0?, 0xc00041c2a0?})
        /tmp/guix-build-terraform-provider-consul-2.20.0.drv-0/source/source/consul/resource_consul_config_entry_concrete.go:111 +0x202
github.com/hashicorp/terraform-provider-consul/consul.configEntryImplementationWrite.func1(0x10442e0?, {0x102a6a0, 0xc00041c2a0})
        /tmp/guix-build-terraform-provider-consul-2.20.0.drv-0/source/source/consul/resource_consul_config_entry_concrete.go:85 +0x2fd
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0xc0003de500, 0xc000781720, 0xc00010f680, {0x102a6a0, 0xc00041c2a0})
        /tmp/guix-build-terraform-provider-consul-2.20.0.drv-0/source/source/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource.go:320 +0x438
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Provider).Apply(0xc00038a680, 0xc0005bf8f0, 0x11c25c3?, 0xf?)
        /tmp/guix-build-terraform-provider-consul-2.20.0.drv-0/source/source/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/provider.go:294 +0x70
github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ApplyResourceChange(0xc000015240, {0xc0007a0a80?, 0x4c4e86?}, 0xc0007a0a80)
        /tmp/guix-build-terraform-provider-consul-2.20.0.drv-0/source/source/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin/grpc_provider.go:895 +0x805
github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x1177e00?, 0xc000015240}, {0x14e77d0, 0xc000793f80}, 0xc0007a0a10, 0x0)
        /tmp/guix-build-terraform-provider-consul-2.20.0.drv-0/source/source/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5/tfplugin5.pb.go:3305 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00020a5a0, {0x14ecda0, 0xc000702680}, 0xc000985320, 0xc0002828a0, 0x1c089a0, 0x0)
        /tmp/guix-build-terraform-provider-consul-2.20.0.drv-0/source/source/vendor/google.golang.org/grpc/server.go:1335 +0xdf3
google.golang.org/grpc.(*Server).handleStream(0xc00020a5a0, {0x14ecda0, 0xc000702680}, 0xc000985320, 0x0)
        /tmp/guix-build-terraform-provider-consul-2.20.0.drv-0/source/source/vendor/google.golang.org/grpc/server.go:1712 +0xa36
google.golang.org/grpc.(*Server).serveStreams.func1.1()
        /tmp/guix-build-terraform-provider-consul-2.20.0.drv-0/source/source/vendor/google.golang.org/grpc/server.go:947 +0xca
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /tmp/guix-build-terraform-provider-consul-2.20.0.drv-0/source/source/vendor/google.golang.org/grpc/server.go:958 +0x15c

Error: The terraform-provider-consul plugin crashed!
```