### PR TITLE
Added ServerExternalAddresses for consul_peering_token

### DIFF
--- a/consul/resource_consul_peering_token.go
+++ b/consul/resource_consul_peering_token.go
@@ -47,6 +47,13 @@ The functionality described here is available only in Consul version 1.13.0 and 
 					Type: schema.TypeString,
 				},
 			},
+			"server_external_addresses": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The addresses for the cluster that generates the peering token. Addresses take the form {host or IP}:port. You can specify one or more load balancers or external IPs that route external traffic to this cluster's Consul servers.",
+			},
 			"peering_token": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -67,9 +74,10 @@ func resourceConsulPeeringTokenCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	req := api.PeeringGenerateTokenRequest{
-		PeerName:  name,
-		Partition: d.Get("partition").(string),
-		Meta:      m,
+		PeerName:                name,
+		Partition:               d.Get("partition").(string),
+		Meta:                    m,
+		ServerExternalAddresses: d.Get("server_external_addresses").([]string),
 	}
 
 	resp, _, err := client.Peerings().GenerateToken(context.Background(), req, wOpts)

--- a/consul/resource_consul_peering_token.go
+++ b/consul/resource_consul_peering_token.go
@@ -18,8 +18,6 @@ func resourceSourceConsulPeeringToken() *schema.Resource {
 
 The ` + "`cluster_peering_token`" + ` resource can be used to generate a peering token that can later be used to establish a peering connection.
 
-~> **Cluster peering is currently in technical preview:** Functionality associated with cluster peering is subject to change. You should never use the technical preview release in secure environments or production scenarios. Features in technical preview may have performance issues, scaling issues, and limited support.
-
 The functionality described here is available only in Consul version 1.13.0 and later.
 `,
 

--- a/consul/resource_consul_peering_token.go
+++ b/consul/resource_consul_peering_token.go
@@ -17,8 +17,6 @@ func resourceSourceConsulPeeringToken() *schema.Resource {
 [Cluster Peering](https://www.consul.io/docs/connect/cluster-peering) can be used to create connections between two or more independent clusters so that services deployed to different partitions or datacenters can communicate.
 
 The ` + "`cluster_peering_token`" + ` resource can be used to generate a peering token that can later be used to establish a peering connection.
-
-The functionality described here is available only in Consul version 1.13.0 and later.
 `,
 
 		Create: resourceConsulPeeringTokenCreate,

--- a/consul/resource_consul_peering_token.go
+++ b/consul/resource_consul_peering_token.go
@@ -66,16 +66,18 @@ func resourceConsulPeeringTokenCreate(d *schema.ResourceData, meta interface{}) 
 	client, _, wOpts := getClient(d, meta)
 	name := d.Get("peer_name").(string)
 
-	m := map[string]string{}
-	for k, v := range d.Get("meta").(map[string]interface{}) {
-		m[k] = v.(string)
+	req := api.PeeringGenerateTokenRequest{
+		PeerName:  name,
+		Partition: d.Get("partition").(string),
+		Meta:      map[string]string{},
 	}
 
-	req := api.PeeringGenerateTokenRequest{
-		PeerName:                name,
-		Partition:               d.Get("partition").(string),
-		Meta:                    m,
-		ServerExternalAddresses: d.Get("server_external_addresses").([]string),
+	for k, v := range d.Get("meta").(map[string]interface{}) {
+		req.Meta[k] = v.(string)
+	}
+
+	for _, address := range d.Get("server_external_addresses").([]interface{}) {
+		req.ServerExternalAddresses = append(req.ServerExternalAddresses, address.(string))
 	}
 
 	resp, _, err := client.Peerings().GenerateToken(context.Background(), req, wOpts)

--- a/consul/resource_consul_peering_token_test.go
+++ b/consul/resource_consul_peering_token_test.go
@@ -53,12 +53,24 @@ func TestAccConsulPeeringToken_basic(t *testing.T) {
 					return nil
 				},
 			},
+			{
+				Config: testAcConsulPeeringTokenServerExternalAddresses,
+			},
 		},
 	})
 }
 
-const testAccConsulPeeringTokenBasic = `
+const (
+	testAccConsulPeeringTokenBasic = `
 resource "consul_peering_token" "basic" {
   peer_name = "hello-world"
 }
 `
+
+	testAcConsulPeeringTokenServerExternalAddresses = `
+resource "consul_peering_token" "basic" {
+  peer_name = "hello-world"
+  server_external_addresses = ["1.2.3.4:8500"]
+}
+`
+)

--- a/docs/resources/peering_token.md
+++ b/docs/resources/peering_token.md
@@ -5,8 +5,6 @@ subcategory: ""
 description: |-
   Cluster Peering https://www.consul.io/docs/connect/cluster-peering can be used to create connections between two or more independent clusters so that services deployed to different partitions or datacenters can communicate.
   The cluster_peering_token resource can be used to generate a peering token that can later be used to establish a peering connection.
-  ~> Cluster peering is currently in technical preview: Functionality associated with cluster peering is subject to change. You should never use the technical preview release in secure environments or production scenarios. Features in technical preview may have performance issues, scaling issues, and limited support.
-  The functionality described here is available only in Consul version 1.13.0 and later.
 ---
 
 # consul_peering_token (Resource)
@@ -14,10 +12,6 @@ description: |-
 [Cluster Peering](https://www.consul.io/docs/connect/cluster-peering) can be used to create connections between two or more independent clusters so that services deployed to different partitions or datacenters can communicate.
 
 The `cluster_peering_token` resource can be used to generate a peering token that can later be used to establish a peering connection.
-
-~> **Cluster peering is currently in technical preview:** Functionality associated with cluster peering is subject to change. You should never use the technical preview release in secure environments or production scenarios. Features in technical preview may have performance issues, scaling issues, and limited support.
-
-The functionality described here is available only in Consul version 1.13.0 and later.
 
 ## Example Usage
 
@@ -38,6 +32,7 @@ resource "consul_peering_token" "token" {
 
 - `meta` (Map of String) Specifies KV metadata to associate with the peering. This parameter is not required and does not directly impact the cluster peering process.
 - `partition` (String)
+- `server_external_addresses` (List of String) The addresses for the cluster that generates the peering token. Addresses take the form {host or IP}:port. You can specify one or more load balancers or external IPs that route external traffic to this cluster's Consul servers.
 
 ### Read-Only
 


### PR DESCRIPTION
Added ServerExternalAddresses field in the `consul_peering_token` resources in order to expose this field of the API.

Source: https://developer.hashicorp.com/consul/api-docs/v1.13.x/peering#serverexternaladdresses