### PR TITLE
fix documentation in Consul_certificate_authority examples

### DIFF
--- a/docs/resources/certificate_authority.md
+++ b/docs/resources/certificate_authority.md
@@ -20,7 +20,7 @@ The `consul_certificate_authority` resource can be used to manage the configurat
 resource "consul_certificate_authority" "connect" {
   connect_provider = "consul"
 
-  config_json = jsondecode({
+  config_json = jsonencode({
     LeafCertTTL         = "24h"
     RotationPeriod      = "2160h"
     IntermediateCertTTL = "8760h"


### PR DESCRIPTION
I corrected a documentation error in the consul_certificate_authority resource. The example now correctly uses the jsonencode function instead of jsondecode.

- [x] Solved issue GH-405

### Updated Documentation:


```
#Using the built-in CA with specific TTL
resource "consul_certificate_authority" "connect" {
  connect_provider = "consul"

  config_json = jsonencode({
    LeafCertTTL         = "24h"
    RotationPeriod      = "2160h"
    IntermediateCertTTL = "8760h"
  })
}
```
