### PR TITLE
Documents disabling deregister_critical_service_after

### DIFF
--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -121,7 +121,7 @@ Required:
 
 Optional:
 
-- `deregister_critical_service_after` (String) The time after which the service is automatically deregistered when in the `critical` state. Defaults to `30s`.
+- `deregister_critical_service_after` (String) The time after which the service is automatically deregistered when in the `critical` state. Defaults to `30s`. Setting to `0` will disable.
 - `header` (Block Set) The headers to send for an HTTP check. The attributes of each header is given below. (see [below for nested schema](#nestedblock--check--header))
 - `http` (String) The HTTP endpoint to call for an HTTP check.
 - `method` (String) The method to use for HTTP health-checks. Defaults to `GET`.


### PR DESCRIPTION
The deregister_critical_service_after feature is not created by default via the API, however it is defaulted to 30s in the terraform provider. For users not wanting to use this feature we can pass a value that Consul will disable it.

It is noted in the consul codebase that setting this to a value less than 1 will disable however it will cause a warn level log entry here: https://github.com/hashicorp/consul/blob/cec66f07431191f8ddab5b74de15db36b34c9055/agent/agent.go#L3442