### PR TITLE
Update test matrix to reflect latest Consul releases

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,10 +1,10 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   test:
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,10 +41,10 @@ jobs:
       uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - name: Install tfplugindocs
       run: |
-        curl -LO https://github.com/hashicorp/terraform-plugin-docs/releases/download/v0.16.0/tfplugindocs_0.16.0_linux_amd64.zip
-        sudo unzip tfplugindocs_0.16.0_linux_amd64.zip tfplugindocs -d /usr/local/bin
-        rm -f tfplugindocs_0.16.0_linux_amd64.zip
-    - name: Generate the documentation
+        curl -LO https://github.com/hashicorp/terraform-plugin-docs/releases/download/v0.19.4/tfplugindocs_0.19.4_linux_amd64.zip
+        sudo unzip tfplugindocs_0.19.4_linux_amd64.zip tfplugindocs -d /usr/local/bin
+        rm -f tfplugindocs_0.19.4_linux_amd64.zip
+    - name: Generate the documentation'
       run: |
         terraform fmt -recursive .
         tfplugindocs generate --ignore-deprecated true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        consul-version: [1.16.6, 1.17.3, 1.18.0]
+        consul-version: [1.17.3, 1.18.2, 1.19.1]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/consul/resource_consul_config_entry_ce_test.go
+++ b/consul/resource_consul_config_entry_ce_test.go
@@ -595,6 +595,8 @@ resource "consul_config_entry" "service_intentions" {
 	name = consul_config_entry.sd.name
 	kind = "service-intentions"
 
+	depends_on = [consul_config_entry.jwt_provider]
+
 	config_json = jsonencode({
 		Sources = [
 			{

--- a/docs/resources/acl_binding_rule.md
+++ b/docs/resources/acl_binding_rule.md
@@ -3,7 +3,7 @@
 page_title: "consul_acl_binding_rule Resource - terraform-provider-consul"
 subcategory: ""
 description: |-
-  Starting with Consul 1.5.0, the consulaclbinding_rule resource can be used to managed Consul ACL binding rules.
+  Starting with Consul 1.5.0, the consul_acl_binding_rule resource can be used to managed Consul ACL binding rules.
 ---
 
 # consul_acl_binding_rule (Resource)

--- a/examples/resources/consul_certificate_authority/resource.tf
+++ b/examples/resources/consul_certificate_authority/resource.tf
@@ -2,7 +2,7 @@
 resource "consul_certificate_authority" "connect" {
   connect_provider = "consul"
 
-  config_json = jsondecode({
+  config_json = jsonencode({
     LeafCertTTL         = "24h"
     RotationPeriod      = "2160h"
     IntermediateCertTTL = "8760h"


### PR DESCRIPTION
Turns out the tests in this repo haven't been running since the primary branch was switched from `master` to `main`. Upon re-enabling them, there were a couple of failures that needed addressing around tf resource dependencies and generated docs.