### PR TITLE
Consume latest release of ghaction-terraform-provider-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
   terraform-provider-release:
     name: 'Terraform Provider Release'
     needs: [go-version, release-notes]
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v5
     secrets:
       hc-releases-github-token: '${{ secrets.HASHI_RELEASES_GITHUB_TOKEN }}'
       hc-releases-host-staging: '${{ secrets.HC_RELEASES_HOST_STAGING }}'

--- a/consul/resource_consul_service.go
+++ b/consul/resource_consul_service.go
@@ -230,7 +230,7 @@ removed during the next [anti-entropy synchronization](https://www.consul.io/doc
 							Type:        schema.TypeString,
 							Optional:    true,
 							Default:     "30s",
-							Description: "The time after which the service is automatically deregistered when in the `critical` state. Defaults to `30s`.",
+							Description: "The time after which the service is automatically deregistered when in the `critical` state. Defaults to `30s`. Setting to `0` will disable.",
 						},
 					},
 				},


### PR DESCRIPTION
This version compensates for changes in GitHub's contract for custom runners