### PR TITLE
Update config_entry.md

### DIFF
--- a/docs/resources/config_entry.md
+++ b/docs/resources/config_entry.md
@@ -263,7 +263,7 @@ resource "consul_config_entry" "exported_services" {
 
 ```hcl
 resource "consul_config_entry" "mesh" {
-	name      = "mesh"
+	#name      = "mesh"  ### The "name" argument field doesn't align with the consul configuration entry object which may cause throw error when customize to any other name instead of "mesh". Ref. https://developer.hashicorp.com/consul/docs/connect/config-entries/mesh#available-fields
 	kind      = "mesh"
   partition = "default"
 


### PR DESCRIPTION
Update "consul_config_entry" for "mesh" resource to not include "name" field, as it doesn't align with Consul Configuration object, and may cause an error if we try to customize the name instead of keeping it default value ie. "mesh".