### PR TITLE
feat: add disable_gossip in admin partition to disable gossip pool

### DIFF
--- a/consul/resource_consul_admin_partition.go
+++ b/consul/resource_consul_admin_partition.go
@@ -31,6 +31,13 @@ func resourceConsulAdminPartition() *schema.Resource {
 				Optional:    true,
 				Description: "Free form partition description.",
 			},
+
+			"disable_gossip": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Disable gossip pool for the partition. Defaults to `false`.",
+				Default:     false,
+			},
 		},
 
 		Importer: &schema.ResourceImporter{
@@ -45,8 +52,9 @@ func resourceConsulAdminPartitionCreate(d *schema.ResourceData, meta interface{}
 	name := d.Get("name").(string)
 
 	partition := &api.Partition{
-		Name:        name,
-		Description: d.Get("description").(string),
+		Name:          name,
+		Description:   d.Get("description").(string),
+		DisableGossip: d.Get("disable_gossip").(bool),
 	}
 
 	_, _, err := partitions.Create(context.TODO(), partition, wOpts)
@@ -77,6 +85,7 @@ func resourceConsulAdminPartitionRead(d *schema.ResourceData, meta interface{}) 
 	sw := newStateWriter(d)
 	sw.set("name", partition.Name)
 	sw.set("description", partition.Description)
+	sw.set("disable_gossip", partition.DisableGossip)
 
 	return sw.error()
 }
@@ -87,8 +96,9 @@ func resourceConsulAdminPartitionUpdate(d *schema.ResourceData, meta interface{}
 	name := d.Get("name").(string)
 
 	partition := &api.Partition{
-		Name:        name,
-		Description: d.Get("description").(string),
+		Name:          name,
+		Description:   d.Get("description").(string),
+		DisableGossip: d.Get("disable_gossip").(bool),
 	}
 
 	_, _, err := partitions.Update(context.TODO(), partition, wOpts)

--- a/consul/resource_consul_admin_partition_ent_test.go
+++ b/consul/resource_consul_admin_partition_ent_test.go
@@ -25,6 +25,7 @@ func TestAccConsulAdminParition_EntBasic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("consul_admin_partition.test", "name", "hello"),
 					resource.TestCheckResourceAttr("consul_admin_partition.test", "description", "world"),
+					resource.TestCheckResourceAttr("consul_admin_partition.test", "disable_gossip", "true"),
 				),
 			},
 			{
@@ -38,6 +39,7 @@ func TestAccConsulAdminParition_EntBasic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("consul_admin_partition.test", "name", "hello"),
 					resource.TestCheckResourceAttr("consul_admin_partition.test", "description", "world"),
+					resource.TestCheckResourceAttr("consul_admin_partition.test", "disable_gossip", "true"),
 				),
 			},
 			{
@@ -53,5 +55,6 @@ const testAccConsulAdminPartitionBasic = `
 resource "consul_admin_partition" "test" {
 	name        = "hello"
 	description = "world"
+	disable_gossip = true
 }
 `

--- a/docs/resources/admin_partition.md
+++ b/docs/resources/admin_partition.md
@@ -27,6 +27,7 @@ The following arguments are supported:
 
 * `name` - (Required) The partition name. This must be a valid DNS hostname label.
 * `description` - (Optional) Free form partition description.
+* `disable_gossip` - (Optional). Disable gossip pool for the partition. Defaults to `false`.
 
 ## Attributes Reference
 
@@ -34,6 +35,7 @@ The following attributes are exported:
 
 * `name` - The partition name.
 * `description` - The partition description.
+* `disable_gossip` - (Optional). Disable gossip pool for the partition. Defaults to `false`.
 
 ## Import
 

--- a/templates/resources/admin_partition.md
+++ b/templates/resources/admin_partition.md
@@ -27,6 +27,7 @@ The following arguments are supported:
 
 * `name` - (Required) The partition name. This must be a valid DNS hostname label.
 * `description` - (Optional) Free form partition description.
+* `disable_gossip` - (Optional). Disable gossip pool for the partition. Defaults to `false`.
 
 ## Attributes Reference
 
@@ -34,6 +35,7 @@ The following attributes are exported:
 
 * `name` - The partition name.
 * `description` - The partition description.
+* `disable_gossip` - (Optional). Disable gossip pool for the partition. Defaults to `false`.
 
 ## Import
 


### PR DESCRIPTION
Addresses #432  - Support DisableGossip for consul_admin_partition resource.

The DisableGossip field is already present in [type Partition](https://pkg.go.dev/github.com/hashicorp/consul/api#Partition) in the consul API. This PR adds the disable_gossip to the schema.